### PR TITLE
Add Claude Code badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ At 100% AI Readiness, AI stops guessing and starts knowing. Live bi-sync between
 [![Homebrew](https://img.shields.io/badge/Homebrew-faf--cli-orange)](https://github.com/Wolfe-Jam/homebrew-faf)
 [![Website](https://img.shields.io/badge/Website-faf.one-orange)](https://faf.one)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Claude Code](https://img.shields.io/badge/Claude_Code-enabled-00D4D4)](https://github.com/anthropics/claude-code-action)
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a Claude Code enabled badge to the README badge row

## Test plan
- [ ] Badge renders correctly on GitHub
- [ ] Claude Code auto-review triggers on this PR

@claude Please review this PR and confirm the Claude Code integration is working.