### PR TITLE
Add citation infra + fix IANA-singular drift (both papers cited)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,47 @@
+cff-version: 1.2.0
+type: software
+message: "If you use faf-cli or the .faf / .fafm formats in your work, please cite the format papers in `preferred-citation` and `references` below."
+title: "faf-cli — CLI for the .faf and .fafm IANA-registered formats"
+authors:
+  - family-names: Wolfe
+    given-names: James
+    orcid: "https://orcid.org/0009-0007-0801-3841"
+    affiliation: "FAF Foundation"
+license: MIT
+repository-code: "https://github.com/Wolfe-Jam/faf-cli"
+url: "https://faf.one"
+keywords:
+  - .faf
+  - .fafm
+  - AI agent context
+  - AI agent memory
+  - IANA-registered format
+  - CLI
+preferred-citation:
+  type: article
+  title: "Format-Driven AI Context Architecture: The .faf Standard for Persistent Project Understanding"
+  authors:
+    - family-names: Wolfe
+      given-names: James
+      orcid: "https://orcid.org/0009-0007-0801-3841"
+      affiliation: "FAF Foundation"
+  year: 2025
+  month: 11
+  doi: 10.5281/zenodo.18251362
+  url: "https://doi.org/10.5281/zenodo.18251362"
+  publisher:
+    name: "Zenodo"
+references:
+  - type: article
+    title: "Permanent Memory and Instant Recall: The .fafm Standard for Multi-Profile AI Agent Memory"
+    authors:
+      - family-names: Wolfe
+        given-names: James
+        orcid: "https://orcid.org/0009-0007-0801-3841"
+        affiliation: "FAF Foundation"
+    year: 2026
+    month: 5
+    doi: 10.5281/zenodo.20348942
+    url: "https://doi.org/10.5281/zenodo.20348942"
+    publisher:
+      name: "Zenodo"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- faf: faf-cli | TypeScript | cli | CLI for the .faf format — IANA-registered AI context that versions with your code -->
+<!-- faf: faf-cli | TypeScript | cli | CLI for the .faf and .fafm IANA-registered formats — AI context + memory that versions with your code -->
 <!-- faf: doc=readme | canonical=project.faf | score=100 | family=FAF -->
 
 <div style="display: flex; align-items: center; gap: 12px;">
@@ -275,6 +275,41 @@ If `faf-cli` has been useful, consider starring the repo — it helps others fin
 
 MIT — Free and open source
 
-**IANA-registered:** [`application/vnd.faf+yaml`](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)
+**IANA-registered:** [`application/vnd.faf+yaml`](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml) (Context) · [`application/vnd.fafm+yaml`](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml) (Memory)
 
 *format | driven 🏎️⚡️ [wolfejam.dev](https://wolfejam.dev)*
+
+## Citation
+
+If you use `.faf` (and/or `.fafm`) in research or production, please cite the format papers:
+
+> Wolfe, J. (2025). *Format-Driven AI Context Architecture: The .faf Standard for Persistent Project Understanding*. Zenodo. https://doi.org/10.5281/zenodo.18251362
+
+> Wolfe, J. (2026). *Permanent Memory and Instant Recall: The .fafm Standard for Multi-Profile AI Agent Memory*. Zenodo. https://doi.org/10.5281/zenodo.20348942
+
+### BibTeX
+
+```bibtex
+@article{wolfe2025faf,
+  title     = {Format-Driven AI Context Architecture: The .faf Standard for Persistent Project Understanding},
+  author    = {Wolfe, James},
+  year      = {2025},
+  month     = {nov},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.18251362},
+  url       = {https://doi.org/10.5281/zenodo.18251362}
+}
+
+@article{wolfe2026fafm,
+  title     = {Permanent Memory and Instant Recall: The .fafm Standard for Multi-Profile AI Agent Memory},
+  author    = {Wolfe, James},
+  year      = {2026},
+  month     = {may},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.20348942},
+  url       = {https://doi.org/10.5281/zenodo.20348942}
+}
+```
+
+[![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)[![DOI: Memory paper](https://img.shields.io/badge/DOI-Memory%20paper-FF6B35)](https://doi.org/10.5281/zenodo.20348942)
+


### PR DESCRIPTION
## Summary

faf-cli handles both `.faf` and `.fafm` formats but the README only mentioned `.faf` for IANA registration. This PR:

- **Adds CITATION.cff** (CFF 1.2.0) — `preferred-citation` = Context paper (foundational); `references` += Memory paper (.fafm).
- **Adds ## Citation section** with both papers + BibTeX + Option-1 orange DOI badges side-by-side.
- **Fixes IANA-singular drift** in line 1 (faf-stamp comment) and line 278 — now acknowledges both registered formats.

Companion citation infrastructure to:
- Wolfe-Jam/faf#10 (in flight)
- Wolfe-Jam/grok-faf-voice#1 + #3 (merged)
- Wolfe-Jam/claude-fafm-sdk#1 + #2 (merged)

## Receipts

- Context paper: DOI `10.5281/zenodo.18251362` (Zenodo, Nov 2025)
- Memory paper: DOI `10.5281/zenodo.20348942` (Zenodo, May 2026)
- IANA: `vnd.faf+yaml` (2025-10-30), `vnd.fafm+yaml` (2026-05-13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)