### PR TITLE
Master template: cohort credibility badges + citation + IANA drift fix

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,47 @@
+cff-version: 1.2.0
+type: software
+message: "If you use faf-cli or the .faf / .fafm IANA-registered formats in your work, please cite the format papers in `preferred-citation` and `references` below."
+title: "faf-cli — CLI for the .faf and .fafm IANA-registered formats"
+authors:
+  - family-names: Wolfe
+    given-names: James
+    orcid: "https://orcid.org/0009-0007-0801-3841"
+    affiliation: "FAF Foundation"
+license: MIT
+repository-code: "https://github.com/Wolfe-Jam/faf-cli"
+url: "https://faf.one"
+keywords:
+  - .faf
+  - .fafm
+  - CLI
+  - AI agent context
+  - AI agent memory
+  - IANA-registered format
+preferred-citation:
+  type: article
+  title: "Format-Driven AI Context Architecture: The .faf Standard for Persistent Project Understanding"
+  authors:
+    - family-names: Wolfe
+      given-names: James
+      orcid: "https://orcid.org/0009-0007-0801-3841"
+      affiliation: "FAF Foundation"
+  year: 2025
+  month: 11
+  doi: 10.5281/zenodo.18251362
+  url: "https://doi.org/10.5281/zenodo.18251362"
+  publisher:
+    name: "Zenodo"
+references:
+  - type: article
+    title: "Permanent Memory and Instant Recall: The .fafm Standard for Multi-Profile AI Agent Memory"
+    authors:
+      - family-names: Wolfe
+        given-names: James
+        orcid: "https://orcid.org/0009-0007-0801-3841"
+        affiliation: "FAF Foundation"
+    year: 2026
+    month: 5
+    doi: 10.5281/zenodo.20348942
+    url: "https://doi.org/10.5281/zenodo.20348942"
+    publisher:
+      name: "Zenodo"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- faf: faf-cli | TypeScript | cli | CLI for the .faf format — IANA-registered AI context that versions with your code -->
+<!-- faf: faf-cli | TypeScript | cli | CLI for the .faf and .fafm IANA-registered formats — AI context + memory that versions with your code -->
 <!-- faf: doc=readme | canonical=project.faf | score=100 | family=FAF -->
 
 <div style="display: flex; align-items: center; gap: 12px;">
@@ -178,6 +178,10 @@ Run `faf --help` for full options.
 
 ```bash
 # ANY GitHub repo — no clone, no install, 2 seconds
+
+[![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)[![IANA: vnd.fafm+yaml](https://img.shields.io/badge/IANA-vnd.fafm%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml)
+[![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)[![DOI: Memory paper](https://img.shields.io/badge/DOI-Memory%20paper-FF6B35)](https://doi.org/10.5281/zenodo.20348942)
+
 bunx faf-cli git https://github.com/facebook/react
 
 # Your own project
@@ -271,10 +275,43 @@ If `faf-cli` has been useful, consider starring the repo — it helps others fin
 
 ---
 
+
+## Citation
+
+If you use `faf-cli` or the `.faf` / `.fafm` formats in research or production, please cite the format papers:
+
+> Wolfe, J. (2025). *Format-Driven AI Context Architecture: The .faf Standard for Persistent Project Understanding*. Zenodo. https://doi.org/10.5281/zenodo.18251362
+
+> Wolfe, J. (2026). *Permanent Memory and Instant Recall: The .fafm Standard for Multi-Profile AI Agent Memory*. Zenodo. https://doi.org/10.5281/zenodo.20348942
+
+### BibTeX
+
+```bibtex
+@article{wolfe2025faf,
+  title     = {Format-Driven AI Context Architecture: The .faf Standard for Persistent Project Understanding},
+  author    = {Wolfe, James},
+  year      = {2025},
+  month     = {nov},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.18251362},
+  url       = {https://doi.org/10.5281/zenodo.18251362}
+}
+
+@article{wolfe2026fafm,
+  title     = {Permanent Memory and Instant Recall: The .fafm Standard for Multi-Profile AI Agent Memory},
+  author    = {Wolfe, James},
+  year      = {2026},
+  month     = {may},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.20348942},
+  url       = {https://doi.org/10.5281/zenodo.20348942}
+}
+```
+
 ## License
 
 MIT — Free and open source
 
-**IANA-registered:** [`application/vnd.faf+yaml`](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)
+**IANA-registered:** [`application/vnd.faf+yaml`](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml) (Context Layer) · [`application/vnd.fafm+yaml`](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml) (Memory Layer)
 
 *format | driven 🏎️⚡️ [wolfejam.dev](https://wolfejam.dev)*


### PR DESCRIPTION
Applies the master template cohort credibility badges + citation infrastructure locked on Wolfe-Jam/faf#10, plus fixes IANA-singular drift in line 1 and line 278.

**Both-formats class** — 2+2 cohort badges at top:
`[IANA: vnd.faf+yaml][IANA: vnd.fafm+yaml]`
`[DOI: Context paper][DOI: Memory paper]`

Plus:
- New `CITATION.cff` (CFF 1.2.0) — `preferred-citation` = Context paper, `references` += Memory paper.
- New `## Citation` section with both papers + BibTeX.
- IANA-singular drift fix in line 1 (faf-stamp) and line 278.

Per `feedback-update-via-repos-canonical-channel` doctrine — same canonical pattern across all FAF cohort repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)