### PR TITLE
README: add Home line below cohort badges (→ faf.one)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Run `faf --help` for full options.
 [![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)[![IANA: vnd.fafm+yaml](https://img.shields.io/badge/IANA-vnd.fafm%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml)
 [![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)[![DOI: Memory paper](https://img.shields.io/badge/DOI-Memory%20paper-FF6B35)](https://doi.org/10.5281/zenodo.20348942)
 
-**Home:** [faf.one](https://faf.one)
+**Home:** [faf.one/cli](https://faf.one/cli)
 bunx faf-cli git https://github.com/facebook/react
 
 # Your own project

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Run `faf --help` for full options.
 [![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)[![IANA: vnd.fafm+yaml](https://img.shields.io/badge/IANA-vnd.fafm%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml)
 [![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)[![DOI: Memory paper](https://img.shields.io/badge/DOI-Memory%20paper-FF6B35)](https://doi.org/10.5281/zenodo.20348942)
 
+**Home:** [faf.one](https://faf.one)
 bunx faf-cli git https://github.com/facebook/react
 
 # Your own project


### PR DESCRIPTION
Master-template cohort addition (prove-it: claude-fafm-sdk#5).

Adds a single canonical "leave the repo here" navigation affordance directly below the credibility badge row:

`**Home:** [faf.one](https://faf.one)`

`faf.one` is the CF asset core canonical CLI home (CF-default when available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)