### PR TITLE
README: lift cohort badges to top, fix Quick Start code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,19 @@
   </div>
 </div>
 
+[![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)[![IANA: vnd.fafm+yaml](https://img.shields.io/badge/IANA-vnd.fafm%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml)
+[![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)[![DOI: Memory paper](https://img.shields.io/badge/DOI-Memory%20paper-FF6B35)](https://doi.org/10.5281/zenodo.20348942)
+
+**Home:** [faf.one/cli](https://faf.one/cli)
+
 **FAF defines. MD instructs. AI codes.**
 
 [![FAF](https://mcpaas.live/badge/Wolfe-Jam/faf-cli.svg)](https://builder.faf.one)
 [![TAF](./badge.svg)](https://github.com/Wolfe-Jam/faf-taf-git)
 [![CI](https://github.com/Wolfe-Jam/faf-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/Wolfe-Jam/faf-cli/actions/workflows/ci.yml)
-[![NPM Downloads](https://img.shields.io/npm/dt/faf-cli?label=total%20downloads&color=00CCFF)](https://www.npmjs.com/package/faf-cli)
 [![npm version](https://img.shields.io/npm/v/faf-cli?color=00CCFF)](https://www.npmjs.com/package/faf-cli)
 [![Homebrew](https://img.shields.io/badge/Homebrew-faf--cli-orange)](https://github.com/Wolfe-Jam/homebrew-faf)
-[![Website](https://img.shields.io/badge/Website-faf.one-orange)](https://faf.one)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Built with Bun](https://img.shields.io/badge/Built_with-Bun-f9f1e1?logo=bun)](https://bun.sh)
 [![project.faf](https://img.shields.io/badge/project.faf-inside-00D4D4)](https://github.com/Wolfe-Jam/faf)
 
 ```
@@ -178,11 +180,6 @@ Run `faf --help` for full options.
 
 ```bash
 # ANY GitHub repo — no clone, no install, 2 seconds
-
-[![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)[![IANA: vnd.fafm+yaml](https://img.shields.io/badge/IANA-vnd.fafm%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml)
-[![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)[![DOI: Memory paper](https://img.shields.io/badge/DOI-Memory%20paper-FF6B35)](https://doi.org/10.5281/zenodo.20348942)
-
-**Home:** [faf.one/cli](https://faf.one/cli)
 bunx faf-cli git https://github.com/facebook/react
 
 # Your own project


### PR DESCRIPTION
## Summary

Completes what `#68` (master template propagation) and `#70` (Home line) intended on 2026-05-23. Both PRs merged — but the diffs landed **inside the Quick Start fenced \`\`\`bash block** at line 182, where they rendered as gray plain text, not as badges. The cohort credibility signal was effectively invisible on the rendered README, and the Quick Start bash example was visually corrupted.

This is the rendered drift caught by the post-arc cross-cohort render check — 6/7 repos rendered correctly, `faf-cli` was the gap.

## Receipt

**Top of README (lift cohort row to canonical position):**
- Cohort badges row `[IANA: vnd.faf+yaml][IANA: vnd.fafm+yaml]` cyan + `[DOI: Context paper][DOI: Memory paper]` orange — now immediately below the hero div, matching the master template on `Wolfe-Jam/faf#10` and the 6 other cohort repos.
- `**Home:** [faf.one/cli](https://faf.one/cli)` — verified 200 — placed below the cohort row, above the existing tagline + badge cluster.

**Quick Start code block (restore to clean state):**
- Removed the misplaced cohort markdown + Home line from inside the \`\`\`bash fence — they were rendering as plain text and breaking the bash example.
- Block now reads as a clean Quick Start: `bunx faf-cli git ...` → `bunx faf-cli init` → `bunx faf-cli auto` → `bunx faf-cli go`.

**Swept (redundant per master pattern):**
- `[NPM Downloads]` — noise (npm version remains)
- `[Website-faf.one-orange]` — replaced by `**Home:**` line
- `[Built with Bun]` — info-only fluff, not load-bearing for cohort identity

**Kept:**
- Hero div + `**FAF defines. MD instructs. AI codes.**` tagline
- `[FAF / mcpaas]`, `[TAF]`, `[CI]`, `[npm version]`, `[Homebrew]`, `[License: MIT]`, `[project.faf-inside]`

## Doctrine lesson

Classic `verify-the-deliverable-not-just-rails` case — PR-merge success was a misleading signal; the actual rendering didn't match the cohort. This PR closes the gap and brings the full FAF Foundation cohort to 7/7 visually coherent.

## Test plan

- [ ] After merge, top of rendered README shows: hero → IANA cyan row → DOI orange row → Home line → tagline → remaining badges
- [ ] Quick Start \`\`\`bash block is clean (no buried markdown)
- [ ] `faf.one/cli` resolves
- [ ] Cohort badges (4 shields.io URLs) all return 2xx

🤖 Generated with [Claude Code](https://claude.com/claude-code)