### PR TITLE
fix(exports): drop broken `bun` condition pointing at unshipped src/ — v6.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- faf: faf-cli | TypeScript | cli | CLI for the .faf format — IANA-registered AI context that versions with your code -->
-<!-- faf: doc=changelog | latest=v6.7.1 | canonical=project.faf | family=FAF -->
+<!-- faf: doc=changelog | latest=v6.7.2 | canonical=project.faf | family=FAF -->
 
 # Changelog
 
@@ -7,6 +7,18 @@ All notable changes to faf-cli will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [6.7.2] - 2026-05-26
+
+### Fixed
+
+- **`exports` map** — removed the `bun` condition that pointed at
+  unshipped `src/index.ts`. Bun consumers (downstream FAF MCP servers
+  using `bun test`) couldn't resolve `from 'faf-cli'` against the
+  published tarball; Node was unaffected. Now both runtimes resolve
+  to `dist/index.js` (same code Node was already loading). Removes
+  the need for the `src/utils/faf-cli-bridge.ts` workaround in
+  faf-mcp 2.1.1 + claude-faf-mcp 5.6.1.
 
 ## [6.7.1] - 2026-05-17
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faf-cli",
-  "version": "6.7.1",
+  "version": "6.7.2",
   "description": "Persistent AI Context Standard — project DNA for AI. IANA-registered. Anthropic-approved.",
   "type": "module",
   "icon": "https://faf.one/orange-smiley.svg",
@@ -14,7 +14,6 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "bun": "./src/index.ts",
       "default": "./dist/index.js"
     }
   },


### PR DESCRIPTION
Removes the `bun` exports condition that pointed at `./src/index.ts` (not in the published tarball). Bun consumers couldn't resolve `from 'faf-cli'` against the tarball; Node was unaffected. Now both runtimes resolve to `dist/index.js`.

**Downstream impact:** unblocks dropping the `src/utils/faf-cli-bridge.ts` workaround from faf-mcp 2.1.1 + claude-faf-mcp 5.6.1 + (incoming) grok-faf-mcp 1.4.1. Bridge-removal PRs to follow once those repos bump to ^6.7.2.

Smoke-tested: bun import resolves cleanly, `scoreFafYaml` is a function.
Tests: 748/0 (was 748/0). tsc clean.