### PR TITLE
docs: add FAF Trophy badge to README (cohort sweep)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   </div>
 </div>
 
+[![FAF Trophy 100%](https://img.shields.io/badge/FAF-%F0%9F%8F%86%20100%25-000000?labelColor=FF6B35)](https://faf.one)
 [![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)[![IANA: vnd.fafm+yaml](https://img.shields.io/badge/IANA-vnd.fafm%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml)
 [![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)[![DOI: Memory paper](https://img.shields.io/badge/DOI-Memory%20paper-FF6B35)](https://doi.org/10.5281/zenodo.20348942)
 


### PR DESCRIPTION
Cohort fan of [Wolfe-Jam/faf-mcp#50](https://github.com/Wolfe-Jam/faf-mcp/pull/50) (merged). Verbatim badge — same orange/black, same URL, same insertion pattern across the whole FAF family.

Doctrine: Trophy is the only releasable state for FAF-family packages (CLAUDE.md + pubpro FAF Gate). This badge stamps that release-gate truth on every public repo.

![FAF Trophy 100%](https://img.shields.io/badge/FAF-%F0%9F%8F%86%20100%25-000000?labelColor=FF6B35)