### PR TITLE
feat: server-card app-type + faf export --card generator

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -115,6 +115,7 @@ program
   .option('--grok', 'Wire grok-faf-mcp into .grok/config.toml')
   .option('--conductor', 'Generate conductor config')
   .option('--html', 'Generate project.html (visual render of project.faf)')
+  .option('--card', 'Generate MCP Server Card (.well-known/mcp/server-card) with the FAF context-block')
   .option('--all', 'Generate all formats')
   .action((options) => exportCommand(options));
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -4,6 +4,7 @@ import { writeCursorrules } from '../interop/cursorrules.js';
 import { writeGeminiMd } from '../interop/gemini.js';
 import { writeGrokConfig } from '../interop/grok.js';
 import { writeProjectHtml } from '../interop/projecthtml.js';
+import { writeServerCard } from '../interop/servercard.js';
 import { scoreFafYaml } from '../core/scorer.js';
 import { dim, fafCyan } from '../ui/colors.js';
 
@@ -14,6 +15,7 @@ export interface ExportOptions {
   grok?: boolean;
   conductor?: boolean;
   html?: boolean;
+  card?: boolean;
   all?: boolean;
 }
 
@@ -33,7 +35,8 @@ export function exportCommand(options: ExportOptions = {}): void {
       !options.gemini &&
       !options.grok &&
       !options.conductor &&
-      !options.html);
+      !options.html &&
+      !options.card);
 
   if (exportAll || options.agents) {
     writeAgentsMd(dir, data);
@@ -63,6 +66,15 @@ export function exportCommand(options: ExportOptions = {}): void {
     const result = scoreFafYaml(readFafRaw(fafPath));
     writeProjectHtml(dir, data, result, fafPath);
     console.log(`  project.html`);
+  }
+
+  // MCP Server Card. Explicit via --card, OR by default for server-card projects
+  // (app_type: server-card) on a plain export — the card carries the FAF
+  // context-block in _meta, so FAF context ships by default.
+  const isServerCard = data.app_type === 'server-card' || data.project?.type === 'server-card';
+  if (options.card || (exportAll && isServerCard)) {
+    const out = writeServerCard(dir, data);
+    console.log(`  ${out.replace(`${dir}/`, '')}`);
   }
 
   console.log(`${fafCyan('exported')} ${dim(`from ${fafPath}`)}`);

--- a/src/core/slots.ts
+++ b/src/core/slots.ts
@@ -136,8 +136,8 @@ export function isPlaceholder(value: unknown): boolean {
   return false;
 }
 
-/** App-type to active category mapping. The canonical 23-type ladder —
- *  20 detectable apps + `about` (non-app, 0 slots, owner-attested)
+/** App-type to active category mapping. The canonical 24-type ladder —
+ *  21 detectable apps + `about` (non-app, 0 slots, owner-attested)
  *  + `encyclopedia` (curated knowledge surface, FAFipedia and similar)
  *  + `intent` (human-intent seed from builder.faf.one, not auto-detected).
  *  (See v6.6.md doctrine memory + fafipedia-vs-grokipedia-architecture.)
@@ -181,6 +181,12 @@ export const APP_TYPE_CATEGORIES: Record<string, SlotCategory[]> = {
   sdk: ['project', 'human', 'universal'],
   wasm: ['project', 'human', 'universal'],
   html: ['project', 'human', 'universal'],
+  // server-card: a published MCP Server Card (discovery manifest) — artifact-class
+  // like sdk/wasm/html. Identity + human context + build/ship matter; frontend,
+  // backend and DB are N/A. By design it carries the FAF context-block in the
+  // card's `_meta["one.faf/context"]` by default — so anyone generating a Server
+  // Card through FAF gets FAF context for free. See faf-server-card-ref.
+  'server-card': ['project', 'human', 'universal'],
 
   // 16 slots — project + frontend + human + universal
   frontend: ['project', 'frontend', 'human', 'universal'],

--- a/src/interop/servercard.ts
+++ b/src/interop/servercard.ts
@@ -1,0 +1,114 @@
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import type { FafData } from '../core/types.js';
+
+/**
+ * Generate an MCP Server Card (SEP-2127) from a .faf.
+ *
+ * The card is a published discovery manifest. By design it carries the FAF
+ * context-block in `_meta["one.faf/context"]` — so every Server Card produced
+ * through FAF ships FAF context by default. The block is byte-identical to the
+ * one in faf-server-card-ref and to `.fafa` provenance: one context, every door.
+ *
+ * Honest-first: no score is baked (it would go stale on disk); the block points
+ * to the .faf and asserts the score is deterministic. The card omits `remotes`
+ * unless a deployment URL is supplied — it must not claim an endpoint it lacks.
+ */
+
+export interface ServerCardOptions {
+  /** Pointer to the .faf context (default: ./project.faf). */
+  fafPointer?: string;
+  /** Optional live endpoint; adds a streamable-http remote when set. */
+  remoteUrl?: string;
+  /** Override timestamp (tests); otherwise .faf `generated`, else now. */
+  now?: string;
+}
+
+const MEDIA_TYPE = 'application/vnd.faf+yaml';
+const SCHEMA = 'https://static.modelcontextprotocol.io/schemas/v1/server-card.schema.json';
+const NAME_RE = /^[a-zA-Z0-9.-]+\/[a-zA-Z0-9._-]+$/;
+
+/** Derive a reverse-DNS `namespace/name` for the card. */
+function serverName(data: FafData): string {
+  const raw = String(data.project?.name ?? 'project').trim();
+  if (raw.includes('/') && NAME_RE.test(raw)) return raw; // already namespaced
+
+  const homepage = (data.project?.homepage ??
+    data.project?.website ??
+    data.project?.url) as string | undefined;
+  let ns = 'local';
+  if (homepage) {
+    try {
+      const host = new URL(homepage).hostname.replace(/^www\./, '');
+      ns = host.split('.').reverse().join('.'); // faf.one -> one.faf
+    } catch {
+      /* keep 'local' */
+    }
+  }
+  const name = raw.replace(/[^a-zA-Z0-9._-]/g, '-').replace(/^-+|-+$/g, '') || 'project';
+  return `${ns}/${name}`;
+}
+
+/** Server Card `description` is capped at 100 chars; never empty. */
+function clampDescription(data: FafData): string {
+  const src = String(
+    data.project?.goal ?? data.context ?? data.project?.name ?? 'MCP server',
+  )
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!src) return 'MCP server';
+  return src.length <= 100 ? src : src.slice(0, 97).trimEnd() + '...';
+}
+
+/** Build the Server Card object from .faf data. */
+export function generateServerCard(
+  data: FafData,
+  opts: ServerCardOptions = {},
+): Record<string, unknown> {
+  const card: Record<string, unknown> = {
+    $schema: SCHEMA,
+    name: serverName(data),
+    version: String(data.project?.version ?? '0.1.0'),
+    description: clampDescription(data),
+  };
+
+  const title = data.project?.name as string | undefined;
+  if (title && title.length <= 100) card.title = title;
+
+  const homepage = (data.project?.homepage ??
+    data.project?.website ??
+    data.project?.url) as string | undefined;
+  if (homepage) card.websiteUrl = homepage;
+
+  if (opts.remoteUrl) {
+    card.remotes = [{ type: 'streamable-http', url: opts.remoteUrl }];
+  }
+
+  // The canonical FAF context-block — parity with faf-server-card-ref + .fafa.
+  card._meta = {
+    'one.faf/context': {
+      faf: opts.fafPointer ?? './project.faf',
+      mediaType: MEDIA_TYPE,
+      iana: `https://www.iana.org/assignments/media-types/${MEDIA_TYPE}`,
+      deterministic: true,
+      generated:
+        (data.generated as string | undefined) ?? opts.now ?? new Date().toISOString(),
+    },
+  };
+
+  return card;
+}
+
+/** Write the Server Card to `.well-known/mcp/server-card`. Returns the path. */
+export function writeServerCard(
+  dir: string,
+  data: FafData,
+  opts: ServerCardOptions = {},
+): string {
+  const card = generateServerCard(data, opts);
+  const outDir = join(dir, '.well-known', 'mcp');
+  mkdirSync(outDir, { recursive: true });
+  const out = join(outDir, 'server-card');
+  writeFileSync(out, JSON.stringify(card, null, 2) + '\n', 'utf-8');
+  return out;
+}

--- a/tests/core/app-types.test.ts
+++ b/tests/core/app-types.test.ts
@@ -1,7 +1,7 @@
 /**
  * WJTTC — app-types canonical ladder (v6.6.0)
  *
- * ENGINE: locks the 23-type ladder, slot allocation, and the universal-
+ * ENGINE: locks the 24-type ladder, slot allocation, and the universal-
  *         category extension to small types (cli/library/mcp/frontend/
  *         data-science).
  *
@@ -32,9 +32,9 @@ const CATEGORY_SIZES: Record<SlotCategory, number> = {
   enterprise_ops: 3,
 };
 
-describe('WJTTC ENGINE: app-types canonical ladder (23 types)', () => {
-  test('exactly 23 types defined', () => {
-    expect(Object.keys(APP_TYPE_CATEGORIES).length).toBe(23);
+describe('WJTTC ENGINE: app-types canonical ladder (24 types)', () => {
+  test('exactly 24 types defined', () => {
+    expect(Object.keys(APP_TYPE_CATEGORIES).length).toBe(24);
   });
 
   test('all canonical types present', () => {
@@ -45,7 +45,7 @@ describe('WJTTC ENGINE: app-types canonical ladder (23 types)', () => {
       'intent',
       'documentation',
       'encyclopedia',
-      'cli', 'library', 'sdk', 'wasm', 'html',
+      'cli', 'library', 'sdk', 'wasm', 'html', 'server-card',
       'frontend', 'website', 'mobile', 'extension',
       'mcp', 'backend', 'data-science',
       'fullstack', 'svelte', 'framework', 'monorepo-root',
@@ -73,6 +73,7 @@ describe('WJTTC ENGINE: per-type slot allocation', () => {
     sdk: 12,
     wasm: 12,
     html: 12,
+    'server-card': 12,
     frontend: 16,
     website: 16,
     mobile: 16,

--- a/tests/interop/servercard.test.ts
+++ b/tests/interop/servercard.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from 'bun:test';
+import { generateServerCard } from '../../src/interop/servercard.js';
+import type { FafData } from '../../src/core/types.js';
+
+const faf: FafData = {
+  faf_version: '2.5.2',
+  generated: '2026-05-04T18:00:00.000Z',
+  app_type: 'server-card',
+  project: { name: 'faf-agent', goal: 'The Voice of FAF', main_language: 'Python' },
+};
+
+const NAME_RE = /^[a-zA-Z0-9.-]+\/[a-zA-Z0-9._-]+$/;
+
+describe('🛡️ server card generator', () => {
+  test('emits required Server Card fields', () => {
+    const c = generateServerCard(faf);
+    expect(String(c.$schema)).toContain('server-card.schema.json');
+    expect(typeof c.name).toBe('string');
+    expect(c.version).toBeDefined();
+    expect((c.description as string).length).toBeGreaterThan(0);
+    expect((c.description as string).length).toBeLessThanOrEqual(100);
+  });
+
+  test('name matches MCP reverse-DNS pattern', () => {
+    expect(String(generateServerCard(faf).name)).toMatch(NAME_RE);
+  });
+
+  test('carries the canonical FAF context-block', () => {
+    const c = generateServerCard(faf) as { _meta: Record<string, any> };
+    const ctx = c._meta['one.faf/context'];
+    expect(ctx.mediaType).toBe('application/vnd.faf+yaml');
+    expect(ctx.deterministic).toBe(true);
+    expect(ctx.faf).toBe('./project.faf');
+    expect(ctx.generated).toBe('2026-05-04T18:00:00.000Z'); // from .faf metastamp, not now()
+  });
+
+  test('does NOT bake a score (FAF don\'t lie)', () => {
+    const ctx = (generateServerCard(faf) as any)._meta['one.faf/context'];
+    expect(ctx.score).toBeUndefined();
+    expect(ctx.tier).toBeUndefined();
+  });
+
+  test('homepage derives a reverse-DNS namespace', () => {
+    const c = generateServerCard({ project: { name: 'context', homepage: 'https://faf.one' } });
+    expect(c.name).toBe('one.faf/context');
+  });
+
+  test('omits remotes unless an endpoint is supplied (no false claim)', () => {
+    expect(generateServerCard(faf).remotes).toBeUndefined();
+    const withRemote = generateServerCard(faf, { remoteUrl: 'https://card.faf.one/mcp' });
+    expect((withRemote.remotes as any[])[0].url).toBe('https://card.faf.one/mcp');
+  });
+
+  test('clamps an over-long description to <=100', () => {
+    const long = generateServerCard({ project: { name: 'x', goal: 'g'.repeat(250) } });
+    expect((long.description as string).length).toBeLessThanOrEqual(100);
+  });
+});


### PR DESCRIPTION
## What

Adds the `server-card` app-type and a generator that turns any `.faf` into a conformant **MCP Server Card** carrying the FAF context-block — so FAF context rides MCP's discovery layer by default.

## Changes

**1. `server-card` app-type** (`src/core/slots.ts`)
- 12-slot artifact tier (`project + human + universal`) — a Server Card is a published discovery manifest, like `sdk`/`wasm`/`html`.
- Reuses an existing category bundle → **zero scoring divergence**, cross-impl parity holds (kernels read markers, not categories). Ladder: 23 → 24 types.

**2. `faf export --card`** (`src/interop/servercard.ts`, `src/commands/export.ts`, `src/cli.ts`)
- Derives a conformant Server Card (SEP-2127) from `project.faf` → `.well-known/mcp/server-card`.
- Carries the **canonical FAF context-block** in `_meta["one.faf/context"]` — byte-parity with [`faf-server-card-ref`](https://github.com/Wolfe-Jam/faf-server-card-ref) and `.fafa` provenance.
- **By default** for `app_type: server-card` projects on a plain `faf export`; opt-in via `--card` otherwise.
- **Honest-first:** no baked score (would go stale on disk), omits `remotes` unless an endpoint is supplied, timestamp pulled from the `.faf` metastamp.

## Tests
- 7 unit tests (`tests/interop/servercard.test.ts`) — required fields, reverse-DNS name pattern, context-block, no-baked-score, description clamp, remotes-only-when-supplied.
- Detect suite green (exercises `APP_TYPE_CATEGORIES`).
- CLI-generated card **validated against MCP's own `server-card.schema.json`**.

## Not included (follow-ons)
- `faf init --app-type` (expert declaration lane)
- scanner auto-detection of server-card projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)