### PR TITLE
feat(export): align faf export --card to #22 reserved location

### DIFF
--- a/src/interop/servercard.ts
+++ b/src/interop/servercard.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync } from 'fs';
+import { writeFileSync } from 'fs';
 import { join } from 'path';
 import type { FafData } from '../core/types.js';
 
@@ -99,16 +99,17 @@ export function generateServerCard(
   return card;
 }
 
-/** Write the Server Card to `.well-known/mcp/server-card`. Returns the path. */
+/** Write the Server Card to a `server-card` file. Returns the path.
+ *  Per experimental-ext-server-card#22 the reserved location is
+ *  `<streamable-http-url>/server-card` (no longer `.well-known`); serve the
+ *  emitted file there as `application/mcp-server-card+json`. */
 export function writeServerCard(
   dir: string,
   data: FafData,
   opts: ServerCardOptions = {},
 ): string {
   const card = generateServerCard(data, opts);
-  const outDir = join(dir, '.well-known', 'mcp');
-  mkdirSync(outDir, { recursive: true });
-  const out = join(outDir, 'server-card');
+  const out = join(dir, 'server-card');
   writeFileSync(out, JSON.stringify(card, null, 2) + '\n', 'utf-8');
   return out;
 }


### PR DESCRIPTION
## What

experimental-ext-server-card#22 (merged) moved the Server Card off `.well-known` to the reserved `<streamable-http-url>/server-card`, served as `application/mcp-server-card+json`.

`faf export --card` now writes a `server-card` file (serve it at `<your-mcp-url>/server-card`) instead of `.well-known/mcp/server-card`. Card **content is unchanged**; only the default output path tracks the new convention.

## Tests
- Generator unit tests unaffected (7 pass — they cover `generateServerCard`, not the write path).

Companion to the live reference at [faf-server-card-ref](https://github.com/Wolfe-Jam/faf-server-card-ref), which is already aligned + deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)