### PR TITLE
fix(docs): version-placement doctrine — single dynamic top-left badge + Edition-Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 <div style="display: flex; align-items: center; gap: 12px;">
   <img src="https://www.faf.one/orange-smiley.svg" alt="FAF" width="40" />
   <div>
-    <h1 style="margin: 0; color: #000000;">faf-cli v6.7</h1>
-    <p style="margin: 2px 0 0 0; font-size: 0.85em; letter-spacing: 0.12em; opacity: 0.7; text-transform: uppercase;"><strong>The HTML Edition</strong></p>
+    <h1 style="margin: 0; color: #000000;">faf-cli — The Relentless Edition</h1>
+    <p style="margin: 2px 0 0 0; font-size: 0.85em; letter-spacing: 0.12em; opacity: 0.7; text-transform: uppercase;"><strong>Persistent AI Context Standard</strong></p>
     <p style="margin: 6px 0 0 0;"><strong>Persistent Project Context for AI.</strong></p>
     <p style="margin: 0;"><strong>Define once. Run anywhere.</strong></p>
   </div>
 </div>
 
+[![npm version](https://img.shields.io/npm/v/faf-cli)](https://www.npmjs.com/package/faf-cli)
 [![FAF Trophy 100%](https://img.shields.io/badge/FAF-%F0%9F%8F%86%20100%25-000000?labelColor=FF6B35)](https://faf.one)
 [![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)[![IANA: vnd.fafm+yaml](https://img.shields.io/badge/IANA-vnd.fafm%2Byaml-00D4D4)](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml)
 [![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)[![DOI: Memory paper](https://img.shields.io/badge/DOI-Memory%20paper-FF6B35)](https://doi.org/10.5281/zenodo.20348942)
@@ -22,7 +23,6 @@
 [![FAF](https://mcpaas.live/badge/Wolfe-Jam/faf-cli.svg)](https://builder.faf.one)
 [![TAF](./badge.svg)](https://github.com/Wolfe-Jam/faf-taf-git)
 [![CI](https://github.com/Wolfe-Jam/faf-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/Wolfe-Jam/faf-cli/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/faf-cli?color=00CCFF)](https://www.npmjs.com/package/faf-cli)
 [![Homebrew](https://img.shields.io/badge/Homebrew-faf--cli-orange)](https://github.com/Wolfe-Jam/homebrew-faf)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![project.faf](https://img.shields.io/badge/project.faf-inside-00D4D4)](https://github.com/Wolfe-Jam/faf)

--- a/docs/index.html
+++ b/docs/index.html
@@ -246,10 +246,12 @@
 </head>
 <body>
   <div class="accent-line"></div>
+  <a href="https://github.com/Wolfe-Jam/faf-cli" id="versionBadge" target="_blank" rel="noopener"
+     style="position:fixed;top:16px;left:16px;z-index:9999;background:#ff6600;color:#000;font-size:0.85rem;font-weight:800;padding:4px 14px;border-radius:4px;text-decoration:none;font-family:-apple-system,BlinkMacSystemFont,sans-serif;box-shadow:0 2px 8px rgba(0,0,0,0.3);">v6.8.0</a>
   <div class="container">
     <div class="logo">🍊</div>
     <h1>faf-cli</h1>
-    <div class="tagline">📦 The HTML Edition <span class="version-badge" onclick="showAbout()">v6.7.1</span></div>
+    <div class="tagline">📦 <span class="version-badge" onclick="showAbout()">The Relentless Edition</span></div>
     <div class="registry-line">Bun-native CLI · <code>npm i faf-cli</code> or <code>npm i faf</code> (dual-published)</div>
     <div class="squeeze">FAF defines. MD instructs. AI codes.</div>
 
@@ -300,7 +302,7 @@
     </div>
 
     <div class="bottom-bar">
-      <div class="links"><span class="version-badge" onclick="showAbout()" style="font-size:0.75rem;padding:3px 10px;">v6.7.1</span> &bull; <a href="https://github.com/Wolfe-Jam/faf-cli">GitHub</a> &bull; <a href="https://npmjs.com/package/faf-cli">npm</a> &bull; <a href="https://github.com/Wolfe-Jam/homebrew-faf">Homebrew</a> &bull; <a href="https://faf.one">faf.one</a></div>
+      <div class="links"><span class="version-badge" onclick="showAbout()" style="font-size:0.75rem;padding:3px 10px;">The Relentless Edition</span> &bull; <a href="https://github.com/Wolfe-Jam/faf-cli">GitHub</a> &bull; <a href="https://npmjs.com/package/faf-cli">npm</a> &bull; <a href="https://github.com/Wolfe-Jam/homebrew-faf">Homebrew</a> &bull; <a href="https://faf.one">faf.one</a></div>
       <div class="big-orange">Persistent AI Context Standard — IANA-registered <code>application/vnd.faf+yaml</code> 🍊</div>
       <div style="margin-top:0.5rem;font-size:0.75rem;"><a href="https://mcpaas.live/privacy" style="color:#666;text-decoration:none;">Privacy</a> · <a href="https://mcpaas.live/terms" style="color:#666;text-decoration:none;">Terms</a> · <a href="mailto:team@faf.one" style="color:#666;text-decoration:none;">team@faf.one</a></div>
       <div style="margin-top:0.75rem;padding-top:0.75rem;border-top:1px solid rgba(255,255,255,0.1);font-size:0.8rem;color:#fff;">Part of the <a href="https://faf.one" style="color:#ff6600;text-decoration:none;">FAF.one Family</a> · <a href="https://mcpaas.live" style="color:#888;text-decoration:none;">MCPaaS</a> · <a href="https://radiofaf.com" style="color:#888;text-decoration:none;">RadioFAF</a> · <a href="https://fafdev.tools" style="color:#888;text-decoration:none;">fafdev.tools</a></div>
@@ -308,8 +310,8 @@
   </div>
   <div class="about-overlay" id="aboutOverlay" onclick="if(event.target===this)hideAbout()">
     <div class="about-box">
-      <div class="about-version">v6.7.1</div>
-      <div class="about-title">The HTML Edition</div>
+      <div class="about-version">The Relentless Edition</div>
+      <div class="about-title">Persistent AI Context Standard</div>
       <div class="about-subtitle">Bun-native · Dual-published</div>
       <div class="about-items">
         <div class="about-item"><span>Runtime:</span> Bun-native CLI</div>
@@ -362,6 +364,7 @@
       document.getElementById('aboutOverlay').classList.remove('visible');
     }
     window.addEventListener('load', function() { setTimeout(function() { showAbout(true); }, 500); });
+    fetch('https://registry.npmjs.org/faf-cli/latest').then(r=>r.json()).then(d=>{if(d&&d.version)document.getElementById('versionBadge').textContent='v'+d.version;}).catch(()=>{});
   </script>
 </body>
 </html>


### PR DESCRIPTION
Applies the FAF version-placement doctrine to the faf-cli web page and README: the version appears in exactly **one** display spot per surface, always **top-left**, read **live** so it can't drift. Every other spot uses the **Edition-Name**.

Edition: **The Relentless Edition** (most recent in CHANGELOG, v6.8.0). Live npm version at time of PR: 6.8.0 (the three hardcoded spots were stale at v6.7.1).

### `docs/index.html`
- Added a fixed **top-left** badge (`id="versionBadge"`, links to the GitHub repo) as the single version reference; fallback text `v6.8.0`.
- Added a live fetch before `</body>` that reads `https://registry.npmjs.org/faf-cli/latest` and updates the badge to `v<version>` (can't drift).
- Tagline badge `v6.7.1` → `The Relentless Edition`.
- Bottom-bar links badge `v6.7.1` → `The Relentless Edition`.
- About modal `v6.7.1` / "The HTML Edition" → `The Relentless Edition` / "Persistent AI Context Standard".
- Result: only the badge fallback carries a hardcoded `vX.Y.Z`.

### `README.md`
- h1 `faf-cli v6.7` → `faf-cli — The Relentless Edition` (subtitle "The HTML Edition" → "Persistent AI Context Standard").
- Made `![npm](https://img.shields.io/npm/v/faf-cli)` the **first / top-left** badge; removed the duplicate styled npm badge from lower in the stack.
- Left the "From v6.6.0 onward…" Trophy callout and the "v6.0 — Built with Bun" narrative untouched (release notes, not a display version).

### Verified
- Grep: only the badge fallback `vX.Y.Z` remains in head/display spots.
- `https://registry.npmjs.org/faf-cli/latest` → 200, version 6.8.0.
- `https://img.shields.io/npm/v/faf-cli` → 200.
- HTML parses clean; `versionBadge` id is unique.

---
Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)