### PR TITLE
feat(core): slot-diff content-drift detection (split from #75)

### DIFF
--- a/src/core/slot-diff.ts
+++ b/src/core/slot-diff.ts
@@ -1,0 +1,61 @@
+import { SLOTS, readSlotValue, isPlaceholder } from './slots.js';
+
+/**
+ * Structural slot-diff between two parsed .faf data objects.
+ *
+ * The v2 content-drift signal that SCORE-DELTA is blind to: a slot whose value
+ * changes but stays populated (e.g. `backend: Hono` → `backend: Express`) keeps
+ * the score identical, yet shows here as `changed`. Score-delta says "no drift";
+ * this says where the DNA actually moved.
+ *
+ * Single-sources the slot model from core/slots.ts — the canonical 33-slot
+ * `SLOTS` schema, `readSlotValue` (legacy/canonical path resolution), and
+ * `isPlaceholder` (the one true empty/populated rule). NO re-parsing, NO
+ * duplicated placeholder list — that was exactly the rot the mcpaas-cf spike
+ * risked before this landed in faf-cli where the slot model lives.
+ *
+ * BANKED FOR v2 — unwired. No command/tool calls this yet. It's the building
+ * block `faf refresh` / `refresh_faf` will use to report content drift, and the
+ * spec behind the WJTTC v1 skipped-test marker in grok-faf-mcp.
+ */
+export type SlotChangeStatus = 'added' | 'removed' | 'changed';
+
+export interface SlotChange {
+  /** Canonical slot path, e.g. "human_context.who" or "stack.backend". */
+  path: string;
+  status: SlotChangeStatus;
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  // Slot values are scalars or simple lists in practice; normalized JSON keeps
+  // the comparison stable across arrays/objects without a deep-equal dependency.
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Diff two .faf data objects across the canonical slots. Returns the slots that
+ * were added (empty→populated), removed (populated→empty), or changed
+ * (populated→different value). Empty/placeholder values never count as content.
+ */
+export function diffFafSlots(
+  baseline: Record<string, unknown>,
+  current: Record<string, unknown>,
+): SlotChange[] {
+  const changes: SlotChange[] = [];
+  for (const slot of SLOTS) {
+    const baseVal = readSlotValue(baseline, slot);
+    const curVal = readSlotValue(current, slot);
+    const basePopulated = !isPlaceholder(baseVal);
+    const curPopulated = !isPlaceholder(curVal);
+
+    if (!basePopulated && curPopulated) {
+      changes.push({ path: slot.path, status: 'added' });
+    } else if (basePopulated && !curPopulated) {
+      changes.push({ path: slot.path, status: 'removed' });
+    } else if (basePopulated && curPopulated && !valuesEqual(baseVal, curVal)) {
+      changes.push({ path: slot.path, status: 'changed' });
+    }
+  }
+  return changes;
+}

--- a/tests/core/slot-diff.test.ts
+++ b/tests/core/slot-diff.test.ts
@@ -1,0 +1,47 @@
+/**
+ * core/slot-diff — content-drift detection (banked for v2, unwired).
+ * The signal score-delta is blind to: slot value changed but score stable.
+ * Verifies the diff single-sources slots.ts (paths + isPlaceholder), no regex.
+ */
+import { describe, test, expect } from 'bun:test';
+import { diffFafSlots } from '../../src/core/slot-diff.js';
+
+describe('core/slot-diff — content drift', () => {
+  test('no changes for identical data', () => {
+    const a = {
+      project: { name: 'x', goal: 'ship', main_language: 'TypeScript' },
+      stack: { backend: 'Hono' },
+    };
+    expect(diffFafSlots(a, a)).toEqual([]);
+  });
+
+  test('CHANGED: slot value swaps but stays populated (the score-stable gap)', () => {
+    const a = { stack: { backend: 'Hono' } };
+    const b = { stack: { backend: 'Express' } };
+    expect(diffFafSlots(a, b)).toContainEqual({ path: 'stack.backend', status: 'changed' });
+  });
+
+  test('ADDED: empty → populated', () => {
+    const a = { stack: { backend: 'Hono' } };
+    const b = { stack: { backend: 'Hono', database: 'KV' } };
+    expect(diffFafSlots(a, b)).toContainEqual({ path: 'stack.database', status: 'added' });
+  });
+
+  test('REMOVED: populated → gone', () => {
+    const a = { stack: { backend: 'Hono', database: 'KV' } };
+    const b = { stack: { backend: 'Hono' } };
+    expect(diffFafSlots(a, b)).toContainEqual({ path: 'stack.database', status: 'removed' });
+  });
+
+  test('placeholder counts as empty (uses slots.ts isPlaceholder, not a private list)', () => {
+    const a = { stack: { backend: 'none' } }; // "none" is a canonical placeholder
+    const b = { stack: { backend: 'Hono' } };
+    expect(diffFafSlots(a, b)).toContainEqual({ path: 'stack.backend', status: 'added' });
+  });
+
+  test('human_context slots resolve by canonical path', () => {
+    const a = { human_context: { who: 'devs', what: 'tool' } };
+    const b = { human_context: { who: 'devs', what: 'a different tool' } };
+    expect(diffFafSlots(a, b)).toContainEqual({ path: 'human_context.what', status: 'changed' });
+  });
+});


### PR DESCRIPTION
## What
The finished, standalone half of #75, rebased clean onto today's `main`.

**`src/core/slot-diff.ts`** — content-drift detection: catches the signal score-delta is blind to — a slot's **value** changes but the score stays stable. Built on the canonical `core/slots.ts` (`SLOTS` + `readSlotValue` + `isPlaceholder`) — no regex, no duplicated placeholder list.

## Why split
#75 bundled this finished piece with an **unwired `refresh.ts` stub** and had drifted **14 commits behind main**. This PR lands the part that's done and tested; the `refresh` consolidation stub stays parked on #75 until v2 actually wires it. No dead scaffolding in `main`.

## Receipts (against current main)
- `tsc -p tsconfig.build.json` — clean
- `bun test tests/core/slot-diff.test.ts` — **6/6 pass**
- Additive only: +108 / −0, two files, nothing else imports it yet (zero blast radius)

The slot-diff is the spec behind grok-faf-mcp's WJTTC v1 skipped marker — this is its consolidation home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)