### PR TITLE
fix: render slotignored as N/A on human-facing surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **Windows path-robustness (git-native repoRel)** — `faf diff` / `log` / `hooks` derive the repo-relative `.faf` path from git (`rev-parse --show-prefix`) instead of `path.relative`, so a Windows 8.3 short-name cwd (e.g. `RUNNER~1`) vs git's long-form root can't yield an "outside repository" path. Runtime-independent (bun/node).
+- **Human-facing surfaces render `slotignored` as `N/A`** — the `faf score` slot breakdown and the `faf show` HTML statline now show `N/A` instead of the internal `slotignored` token (e.g. `· 5 N/A`, not `· 5 slotignored`). Display-only: the stored `.faf` value is unchanged (still `slotignored`, the canonical/scored token). `N/A` is the clearer, conventional term for a slot the project's app-type doesn't need.
 
 ### CI
 - **`release.yml` Windows matrix removed** — mirrors `ci.yml`'s documented Windows exclusion (bun timeouts); closes the split where the badge workflow skipped Windows but the release pipeline gated on it *post-tag*. A real pre-merge Windows gate is a tracked decision.

--- a/src/interop/projecthtml.ts
+++ b/src/interop/projecthtml.ts
@@ -149,7 +149,7 @@ footer strong{color:#e6edf3}
 ${
   isTrophy
     ? '<p class="award statline"><span class="awd-pre">✅ All Required slots filled.</span> <span class="awd-win">100% Trophy 🏆 Awarded</span></p>'
-    : `<p class="muted statline">${result.populated}/${result.active} slots populated · ${result.total} total${stackIgnored ? ` · ${stackIgnored} slotignored` : ''}</p>`
+    : `<p class="muted statline">${result.populated}/${result.active} slots populated · ${result.total} total${stackIgnored ? ` · ${stackIgnored} N/A` : ''}</p>`
 }
 
 <section>

--- a/src/ui/display.ts
+++ b/src/ui/display.ts
@@ -38,7 +38,7 @@ function displaySlotBreakdown(result: ScoreResult): void {
     const icon = state === 'populated' ? fafCyan('●')
       : state === 'slotignored' ? dim('—')
       : dim('○');
-    console.log(`  ${icon} ${state === 'slotignored' ? dim(path) : path}`);
+    console.log(`  ${icon} ${state === 'slotignored' ? dim(`${path}: N/A`) : path}`);
   }
 }
 


### PR DESCRIPTION
## What
Human-facing surfaces now render the internal `slotignored` slot state as **`N/A`**:
- `faf score` slot breakdown → `— css_framework: N/A`
- `faf show` HTML statline → `· 5 N/A` (was `· 5 slotignored`)

## Why
`slotignored` is the internal token for a slot the project's app-type doesn't need (pre-approved as not-applicable). Surfacing that raw token to a person reads as jargon; `N/A` is the clear, conventional term.

**Display-only** — the stored `.faf` value stays `slotignored` (canonical, scored), so parsing and scoring are unchanged. The token stays code-side; `N/A` is just how it's shown.

## Scope
- `src/ui/display.ts` — `faf score` slot breakdown render
- `src/interop/projecthtml.ts` — `faf show` HTML statline
- Doc generation already omits not-needed slots (active-only) — no change needed there.

## Tests
Full suite green: **1087 pass, 0 fail**. Data-assertion tests are unaffected (the stored value is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
