### PR TITLE
feat(server-card): central title emitter — registryTitle() + `faf server-card`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import { compileCommand } from './commands/compile.js';
 import { decompileCommand } from './commands/decompile.js';
 import { checkCommand } from './commands/check.js';
 import { exportCommand } from './commands/export.js';
+import { serverCardCommand } from './commands/server-card.js';
 import { showCommand } from './commands/show.js';
 import { gitCommand } from './commands/git.js';
 import { diffCommand, diffDriverCommand } from './commands/diff.js';
@@ -184,6 +185,17 @@ program
   .option('--card', 'Generate MCP Server Card (.well-known/mcp/server-card) with the FAF context-block')
   .option('--all', 'Generate all formats')
   .action((options) => exportCommand(options));
+
+program
+  .command('server-card')
+  .description('Emit the registry server.json identity (name + title + _meta) from project.faf — the cross-language server-card emitter; patches an existing file')
+  .option('--in <path>', 'Existing server.json to patch (default: ./server.json)')
+  .option('--out <path>', 'Output path (default: same as --in)')
+  .option('--faf <path>', 'project.faf path (default: auto-discover)')
+  .option('--version <version>', 'Set the version field (default: preserve existing)')
+  .option('--generated <iso>', 'Override the _meta generated stamp (default: preserve existing)')
+  .option('--check', 'Print to stdout, do not write (diff/verify — the idempotency-test hook)')
+  .action((options) => serverCardCommand(options));
 
 program
   .command('check [file]')

--- a/src/commands/server-card.ts
+++ b/src/commands/server-card.ts
@@ -1,0 +1,114 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+import { findFafFile, readFaf } from '../interop/faf.js';
+import {
+  registryName,
+  registryTitle,
+  registryMeta,
+  REGISTRY_PUBLISHER_KEY,
+} from '../interop/servercard.js';
+import { dim, fafCyan } from '../ui/colors.js';
+
+export interface ServerCardCommandOptions {
+  in?: string;
+  out?: string;
+  faf?: string;
+  version?: string;
+  generated?: string;
+  check?: boolean;
+}
+
+/** Canonical field order for a registry server.json — keeps the emit byte-stable
+ *  (idempotent) so a repo's B1 test can assert `--check` output == the live file. */
+const FIELD_ORDER = [
+  '$schema',
+  'name',
+  'title',
+  'description',
+  'icons',
+  'version',
+  'repository',
+  'websiteUrl',
+  'packages',
+  'remotes',
+  '_meta',
+] as const;
+
+/**
+ * `faf server-card` — inject the EMITTED IDENTITY (name + title + _meta) from
+ * project.faf into an existing MCP-registry server.json, preserving every
+ * release-managed field (description, icons, version, repository, websiteUrl,
+ * packages) verbatim. The single CROSS-LANGUAGE server-card emitter: TS, Python,
+ * and Rust builds all call it, so identity is composed from ONE source — never
+ * forked per repo. (JS repos may instead import `registryTitle`/`registryName`/
+ * `registryMeta` directly; the CLI exists so Python/Rust reach the same source.)
+ *
+ * Patch-mode by design: it does NOT invent packages/version/sha (those are
+ * per-release and per-registry — npm vs pypi vs cargo vs mcpb). Bump the version
+ * with --version; otherwise the existing value is preserved. --check prints to
+ * stdout without writing (the idempotency-test hook).
+ */
+export function serverCardCommand(options: ServerCardCommandOptions = {}): void {
+  const fafPath = options.faf ? resolve(options.faf) : findFafFile();
+  if (!fafPath || !existsSync(fafPath)) {
+    console.error("Error: project.faf not found\n\n  Run 'faf init' to create one.");
+    process.exit(2);
+  }
+  const data = readFaf(fafPath);
+
+  const inPath = resolve(options.in ?? './server.json');
+  if (!existsSync(inPath)) {
+    console.error(
+      `Error: ${inPath} not found.\n\n  'faf server-card' patches the identity into an existing registry server.json;\n  it does not create packages/icons. Seed a server.json first, then run this.`,
+    );
+    process.exit(2);
+  }
+  const existing = JSON.parse(readFileSync(inPath, 'utf-8')) as Record<string, unknown>;
+
+  // Preserve the release-managed `generated` stamp so the emit stays idempotent
+  // (no spurious churn on re-run); --generated overrides it at release time.
+  const existingMeta = existing._meta as
+    | Record<string, { 'one.faf/context'?: { generated?: string } }>
+    | undefined;
+  const existingGenerated =
+    existingMeta?.[REGISTRY_PUBLISHER_KEY]?.['one.faf/context']?.generated;
+  const now = options.generated ?? existingGenerated;
+
+  // Compose the identity from faf-cli's single source.
+  const name = registryName(data);
+  const title = registryTitle(data);
+  const emittedMeta = registryMeta(data, { fafPointer: './project.faf', now });
+
+  // Merge: identity from faf-cli; every other field preserved from the live file.
+  const merged: Record<string, unknown> = {
+    ...existing,
+    name,
+    ...(options.version ? { version: options.version } : {}),
+    _meta: { ...((existing._meta as object) ?? {}), ...emittedMeta },
+  };
+  if (title) merged.title = title;
+  else delete merged.title; // omit when unset — never ship an empty title
+
+  // Rebuild in canonical order (identity slots land in the right place even if the
+  // source file lacked a title); carry any repo-specific extra keys after.
+  const ordered: Record<string, unknown> = {};
+  for (const k of FIELD_ORDER) {
+    if (k in merged && merged[k] !== undefined) ordered[k] = merged[k];
+  }
+  for (const k of Object.keys(merged)) {
+    if (!(k in ordered) && merged[k] !== undefined) ordered[k] = merged[k];
+  }
+
+  const json = JSON.stringify(ordered, null, 2) + '\n';
+  if (options.check) {
+    process.stdout.write(json);
+    return;
+  }
+  const outPath = resolve(options.out ?? inPath);
+  writeFileSync(outPath, json);
+  console.error(
+    `${fafCyan('✓')} ${outPath} — name=${name} title=${title ?? '(none)'} ${dim(
+      '(identity emitted from faf-cli)',
+    )}`,
+  );
+}

--- a/src/interop/servercard.ts
+++ b/src/interop/servercard.ts
@@ -99,7 +99,7 @@ export function generateServerCard(
     description: clampDescription(data),
   };
 
-  const title = data.project?.name as string | undefined;
+  const title = registryTitle(data) ?? (data.project?.name as string | undefined);
   if (title && title.length <= 100) card.title = title;
 
   const homepage = (data.project?.homepage ??
@@ -153,6 +153,23 @@ export function registryMeta(
  *  `homepage: https://faf.one` in the .faf to get the correct `one.faf/<name>`. */
 export function registryName(data: FafData): string {
   return serverName(data);
+}
+
+/** The display title for a registry `server.json` — the human-readable card name
+ *  (e.g. "Claude FAF"), sourced from `project.title` in the .faf. This is the
+ *  SINGLE SOURCE of the title across the fleet: JS emitters import it, and the
+ *  `faf server-card` CLI uses it so Python/Rust repos compose the identical
+ *  value (compose-not-fork). Distinct from `registryName` (the reverse-DNS id).
+ *  Returns undefined when unset or >100 chars (the registry cap) so the field is
+ *  omitted rather than shipped invalid — GitHub's registry then derives a name
+ *  from the namespace, so set `project.title` to control the display. */
+export function registryTitle(data: FafData): string | undefined {
+  const raw = (data.project as { title?: unknown } | undefined)?.title;
+  if (typeof raw === 'string') {
+    const t = raw.trim();
+    if (t && t.length <= 100) return t;
+  }
+  return undefined;
 }
 
 /** Write the Server Card to a `server-card` file. Returns the path.

--- a/tests/interop/servercard.test.ts
+++ b/tests/interop/servercard.test.ts
@@ -3,6 +3,7 @@ import {
   generateServerCard,
   registryMeta,
   registryName,
+  registryTitle,
   REGISTRY_PUBLISHER_KEY,
 } from '../../src/interop/servercard.js';
 import type { FafData } from '../../src/core/types.js';
@@ -122,5 +123,36 @@ describe('ENGINE: 🛡️ registry server.json _meta emitter', () => {
     expect(
       registryName({ project: { name: 'claude-faf-mcp', homepage: 'https://faf.one' } }),
     ).toBe('one.faf/claude-faf-mcp');
+  });
+});
+
+describe('ENGINE: 🛡️ registry title — the single source (compose-not-fork)', () => {
+  test('returns project.title (the display card name)', () => {
+    expect(registryTitle({ project: { name: 'claude-faf-mcp', title: 'Claude FAF' } as any })).toBe(
+      'Claude FAF',
+    );
+  });
+
+  test('undefined when no title — the field is omitted, never shipped empty', () => {
+    expect(registryTitle(faf)).toBeUndefined(); // faf has name + goal, no title
+  });
+
+  test('undefined when over the 100-char registry cap (never ship invalid)', () => {
+    expect(registryTitle({ project: { name: 'x', title: 'T'.repeat(101) } as any })).toBeUndefined();
+  });
+
+  test('trims surrounding whitespace', () => {
+    expect(registryTitle({ project: { name: 'x', title: '  Grok FAF  ' } as any })).toBe('Grok FAF');
+  });
+
+  test('generateServerCard title prefers project.title over the reverse-DNS name', () => {
+    const c = generateServerCard({
+      project: { name: 'claude-faf-mcp', title: 'Claude FAF', homepage: 'https://faf.one' } as any,
+    });
+    expect(c.title).toBe('Claude FAF'); // the display title, not "claude-faf-mcp"
+  });
+
+  test('generateServerCard falls back to the name when no title (back-compat)', () => {
+    expect(generateServerCard({ project: { name: 'faf-agent' } }).title).toBe('faf-agent');
   });
 });


### PR DESCRIPTION
## What

A **central server-card title emitter** in faf-cli, so every FAF MCP repo composes its registry `server.json` display title from ONE source — instead of hand-editing a `title` into each `server.json` (the drift that surfaced as **"Faf Claude Faf"** on github.com/mcp until claude-faf-mcp 5.20.0).

## Why

github.com/mcp derives a card name from `namespace + name` when `server.json` carries no `title` — garbling `one.faf/claude-faf-mcp` into "Faf Claude Faf". The fix is a `title` field; but hand-editing it into each repo's emitted `server.json` is exactly the fork/drift FAF avoids. This puts the title logic in faf-cli, once.

## What's in it

- **`registryTitle(data)`** — the single source: `project.title` → the display title (omitted when unset or >100 chars, the registry cap). TS repos import it alongside `registryName` / `registryMeta`.
- **`faf server-card`** — the cross-language CLI (patch-mode): injects `name` + `title` + `_meta` from `project.faf` into an existing `server.json`, preserving the release-managed half (packages / icons / version / sha). Python (gemini) and Rust (rust) repos reach the same source via the `faf` binary. Flags: `--check` (stdout — the idempotency-test hook), `--version`, `--generated`, `--in` / `--out` / `--faf`.
- `generateServerCard` now prefers `project.title` (falls back to the reverse-DNS name — back-compat).
- +6 `registryTitle` tests (servercard suite: **22 pass, 0 fail**).

## Proof

`faf server-card --check` reproduces claude-faf-mcp's live `server.json` **byte-for-byte** — idempotent, the B1-test contract each fleet repo will adopt.

## Rollout (follow-ups, after merge + publish)

claude imports `registryTitle`; grok + faf-mcp wire `faf server-card`; gemini (Python) + rust (Rust) call the binary in their build and migrate to `one.faf`. Target titles: **Grok FAF · .FAF Context · Gemini FAF · Rust FAF**.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*
