### PR TITLE
release: faf-cli 7.0.1 — central server-card title emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- faf: faf-cli | TypeScript | cli | CLI for the .faf format — IANA-registered AI context that versions with your code -->
-<!-- faf: doc=changelog | latest=v7.0.0 | canonical=project.faf | family=FAF -->
+<!-- faf: doc=changelog | latest=v7.0.1 | canonical=project.faf | family=FAF -->
 
 # Changelog
 
@@ -10,7 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-*(Landed on main, not yet released — rides the next version.)*
+## [7.0.1] - 2026-07-01
+
+Patch on The GIT Version — a central, cross-language server-card title emitter, plus honest slot rendering and Windows path-robustness.
+
+### Added
+- **`faf server-card` + `registryTitle()` — the central server-card title emitter.** `project.title` is the single source of a registry `server.json`'s display title; `faf server-card` injects `name` + `title` + `_meta` from `project.faf` into an existing server.json (patch-mode — preserving the release-managed half: packages/icons/version/sha), so every FAF MCP repo (TS, Python, or Rust) composes the same identity instead of hand-editing a title. That hand-edited drift is what garbled `one.faf/claude-faf-mcp` into "Faf Claude Faf" on github.com/mcp. `--check` prints without writing (the idempotency-test hook); `--version` / `--generated` for releases. `generateServerCard` now prefers `project.title` (falls back to the name — back-compat).
 
 ### Fixed
 - **Windows path-robustness (git-native repoRel)** — `faf diff` / `log` / `hooks` derive the repo-relative `.faf` path from git (`rev-parse --show-prefix`) instead of `path.relative`, so a Windows 8.3 short-name cwd (e.g. `RUNNER~1`) vs git's long-form root can't yield an "outside repository" path. Runtime-independent (bun/node).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,5 +23,5 @@ CLI for the `.faf` format — persistent AI context that versions with your code
 
 ---
 
-*STATUS: BI-SYNC ACTIVE — 2026-06-27T16:14:39.059Z*
+*STATUS: BI-SYNC ACTIVE — 2026-07-01T03:17:06.702Z*
 <!-- faf:end -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faf-cli",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Persistent AI Context Standard — project DNA for AI. IANA-registered. Anthropic-merged.",
   "type": "module",
   "icon": "https://faf.one/orange-smiley.svg",


### PR DESCRIPTION
## faf-cli 7.0.1 — patch release (protects the clean 7.0 round)

Release commit for **faf-cli 7.0.1** — version bump + CHANGELOG + bi-sync. The code already landed on `main` (#87, #86, Windows hardening); this cuts the release. Patch — **no new edition** (inherits The GIT Version).

### What 7.0.1 ships
- **`faf server-card` + `registryTitle()`** (#87) — the central, cross-language server-card title emitter (compose-not-fork). `project.title` is the single source; TS/Python/Rust repos compose the same identity instead of hand-editing a title. Fixes the "Faf Claude Faf" drift class at the root.
- **`slotignored` → `N/A`** on human-facing surfaces (#86).
- **Windows `repoRel`** git-native canonicalization; `release.yml` aligned to `ci.yml`'s Windows exclusion.

### Gates (green)
- CI on main ✅ · Full suite **1093 pass, 0 fail** · FAF 🏆 100% · Doc Gate 101 ✅ (all stamps 7.0.1) · Dry-run 34 files / 720 kB

Merge → npm publish + `faf` dual-publish + tag + Homebrew auto-update.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*
