### PR TITLE
fix(server-card): rename --version to --set-version (global flag clash)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -192,7 +192,7 @@ program
   .option('--in <path>', 'Existing server.json to patch (default: ./server.json)')
   .option('--out <path>', 'Output path (default: same as --in)')
   .option('--faf <path>', 'project.faf path (default: auto-discover)')
-  .option('--version <version>', 'Set the version field (default: preserve existing)')
+  .option('--set-version <version>', 'Set the version field (default: preserve existing). NOTE: not --version, which is the global CLI-version flag')
   .option('--generated <iso>', 'Override the _meta generated stamp (default: preserve existing)')
   .option('--check', 'Print to stdout, do not write (diff/verify — the idempotency-test hook)')
   .action((options) => serverCardCommand(options));

--- a/src/commands/server-card.ts
+++ b/src/commands/server-card.ts
@@ -13,7 +13,7 @@ export interface ServerCardCommandOptions {
   in?: string;
   out?: string;
   faf?: string;
-  version?: string;
+  setVersion?: string;
   generated?: string;
   check?: boolean;
 }
@@ -45,7 +45,8 @@ const FIELD_ORDER = [
  *
  * Patch-mode by design: it does NOT invent packages/version/sha (those are
  * per-release and per-registry — npm vs pypi vs cargo vs mcpb). Bump the version
- * with --version; otherwise the existing value is preserved. --check prints to
+ * with --set-version (NOT --version, which is the global CLI-version flag);
+ * otherwise the existing value is preserved. --check prints to
  * stdout without writing (the idempotency-test hook).
  */
 export function serverCardCommand(options: ServerCardCommandOptions = {}): void {
@@ -83,7 +84,7 @@ export function serverCardCommand(options: ServerCardCommandOptions = {}): void 
   const merged: Record<string, unknown> = {
     ...existing,
     name,
-    ...(options.version ? { version: options.version } : {}),
+    ...(options.setVersion ? { version: options.setVersion } : {}),
     _meta: { ...((existing._meta as object) ?? {}), ...emittedMeta },
   };
   if (title) merged.title = title;


### PR DESCRIPTION
**Bug (reported by wolfejam):** `faf server-card --version <v>` prints the CLI version instead of setting the card's version field.

**Cause:** the `server-card` command's `--version <version>` option (`cli.ts:195`) collided with commander's **program-level** `.version(VERSION, '-v, --version')` (`cli.ts:48`) — the built-in wins, prints `7.0.1`, and exits before the field is set. The old flag never worked.

**Fix:** rename the option **`--version` → `--set-version`** (`options.version` → `options.setVersion`). The global `-v/--version` is untouched.

**Verified (manual, no existing command-test harness):**
| Test | Result |
|------|--------|
| `server-card --set-version 9.9.9 --check` | ✅ output `"version": "9.9.9"` |
| `faf --version` | ✅ still `7.0.1` (global flag intact) |
| `server-card --help` | ✅ shows `--set-version` + a note pointing at the global flag |

Pure fix (the old flag was broken), so no migration for anyone who had it working — nobody did. **Ship via `/pubpro` as 7.0.2** (this PR is the code fix only).

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*