### PR TITLE
chore(release): faf-cli 7.0.2 — server-card --set-version fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- faf: faf-cli | TypeScript | cli | CLI for the .faf format — IANA-registered AI context that versions with your code -->
-<!-- faf: doc=changelog | latest=v7.0.1 | canonical=project.faf | family=FAF -->
+<!-- faf: doc=changelog | latest=v7.0.2 | canonical=project.faf | family=FAF -->
 
 # Changelog
 
@@ -9,6 +9,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.0.2] - 2026-07-01
+
+### Fixed
+- **`faf server-card --version` clashed with the global CLI `--version`.** The
+  `server-card` option for setting the card's version field collided with
+  commander's program-level `.version()`, so it printed the CLI version (7.0.1)
+  instead of setting the field. Renamed the option to **`--set-version`**; the
+  global `-v`/`--version` is unchanged. The old flag never worked, so this is a
+  pure fix — a follow-on to 7.0.1's server-card title emitter.
 
 ## [7.0.1] - 2026-07-01
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faf-cli",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Persistent AI Context Standard — project DNA for AI. IANA-registered. Anthropic-merged.",
   "type": "module",
   "icon": "https://faf.one/orange-smiley.svg",


### PR DESCRIPTION
**Release prep for `faf-cli 7.0.2`** — version + CHANGELOG for the `server-card --version` → `--set-version` fix already merged in [#89](https://github.com/Wolfe-Jam/faf-cli/pull/89). Publish is via **`/pubpro faf-cli`** after this merges — this PR is prep only.

### What ships
`faf server-card --set-version <v>` now sets the card's version field (it collided with the global `--version` and printed the CLI version instead). Pure fix — the old flag never worked.

### Changes (doc/version only — code is on `main` from #89)
| File | Change |
|------|--------|
| `package.json` | `7.0.1` → `7.0.2` |
| `CHANGELOG.md` | meta-stamp `latest=v7.0.2` + `## [7.0.2]` entry |

Patch → **inherits "The GIT Version"** (no new edition). Stamps consistent — Doc Gate 101 clean.

### After merge
`/pubpro faf-cli` → gates + npm publish + the **`faf` dual-publish** (Step 7a) + Homebrew + registry. Your GO on the publish.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*