### PR TITLE
feat(export): render actionable AGENTS.md sections from existing slots

### DIFF
--- a/src/interop/agents.ts
+++ b/src/interop/agents.ts
@@ -2,49 +2,148 @@ import { join } from 'path';
 import type { FafData } from '../core/types.js';
 import { fafMetaTag } from './claude.js';
 import { injectFafBlock } from './inject.js';
-import { filled, slotLabel } from './labels.js';
+import { filled, slotLabel, titleLabel } from './labels.js';
 
-/** Generate AGENTS.md content from .faf data */
+/** A value carrying real content — non-empty, not slotignored, non-empty array. */
+const present = (v: unknown): boolean =>
+  v != null && v !== '' && v !== 'slotignored' && !(Array.isArray(v) && v.length === 0);
+
+/** Render a slot value for inline display (arrays → comma list). */
+const fmtVal = (v: unknown): string => (Array.isArray(v) ? v.join(', ') : String(v));
+
+/**
+ * Generate AGENTS.md content from .faf data.
+ *
+ * Renders the actionable sections a good AGENTS.md needs (setup/build, tests,
+ * where-things-live, conventions, commit rules, guardrails) by PROJECTING slots
+ * the .faf already carries — `commands`, `key_files`, `ai_instructions`,
+ * `preferences`. No section is invented; an absent slot simply omits its section.
+ */
 export function generateAgentsMd(data: FafData): string {
   const lines: string[] = [];
+  const push = (s = '') => lines.push(s);
 
-  lines.push(fafMetaTag(data));
-  lines.push('');
-  lines.push(`# AGENTS.md — ${data.project?.name ?? 'Project'}`);
-  lines.push('');
-  lines.push('> Auto-generated from project.faf — do not edit directly');
-  lines.push('');
-  lines.push('## Project Context');
-  lines.push('');
+  // Slot blocks used below — some typed on FafData, others ride the index signature.
+  const ai = data.ai_instructions as
+    | { warnings?: string[]; working_style?: Record<string, unknown> }
+    | undefined;
+  const prefs = data.preferences as Record<string, unknown> | undefined;
+  const instant = data.instant_context as { key_files?: string[] } | undefined;
+  const commands = data.commands;
+  const keyFiles = data.key_files ?? instant?.key_files;
 
-  if (data.project?.name) lines.push(`- **Name:** ${data.project.name}`);
-  if (data.project?.goal) lines.push(`- **Goal:** ${data.project.goal}`);
-  if (data.project?.main_language) lines.push(`- **Language:** ${data.project.main_language}`);
+  push(fafMetaTag(data));
+  push();
+  push(`# AGENTS.md — ${data.project?.name ?? 'Project'}`);
+  push();
+  push('> Auto-generated from project.faf — do not edit directly');
+  push();
 
-  lines.push('');
-  lines.push('## Stack');
-  lines.push('');
+  // Orientation
+  push('## Project Context');
+  push();
+  if (data.project?.name) push(`- **Name:** ${data.project.name}`);
+  if (data.project?.goal) push(`- **Goal:** ${data.project.goal}`);
+  if (data.project?.main_language) push(`- **Language:** ${data.project.main_language}`);
+  push();
 
+  // Setup / build / test commands — the actionable core (rendered when authored)
+  if (commands && Object.keys(commands).length > 0) {
+    const entries = Object.entries(commands).filter(([, v]) => present(v));
+    const tests = entries.filter(([k]) => /test/i.test(k));
+    const setup = entries.filter(([k]) => !/test/i.test(k));
+    if (setup.length) {
+      push('## Setup & build');
+      push();
+      push('```bash');
+      for (const [k, v] of setup) push(`${v}    # ${k}`);
+      push('```');
+      push();
+    }
+    if (tests.length) {
+      push('## Run the tests — how you verify your work');
+      push();
+      push('```bash');
+      for (const [, v] of tests) push(v);
+      push('```');
+      push();
+    }
+  }
+
+  // Where things live
+  if (keyFiles && keyFiles.length > 0) {
+    push('## Where things live');
+    push();
+    for (const f of keyFiles) push(`- \`${f}\``);
+    push();
+  }
+
+  // Conventions — working_style + preferences, deduped by label (commit_style → its own section)
+  const conventions = new Map<string, string>();
+  const collect = (obj: Record<string, unknown> | undefined, skip: string[] = []) => {
+    if (!obj) return;
+    for (const [k, v] of Object.entries(obj)) {
+      if (skip.includes(k) || !present(v)) continue;
+      const label = titleLabel(k);
+      if (!conventions.has(label)) conventions.set(label, fmtVal(v));
+    }
+  };
+  collect(ai?.working_style);
+  collect(prefs, ['commit_style']);
+  if (conventions.size > 0) {
+    push('## Conventions');
+    push();
+    for (const [label, val] of conventions) push(`- **${label}:** ${val}`);
+    push();
+  }
+
+  // Commit & PR
+  if (prefs && present(prefs.commit_style)) {
+    push('## Commit & PR');
+    push();
+    push(`- **Commit style:** ${fmtVal(prefs.commit_style)}`);
+    push();
+  }
+
+  // Guardrails — do NOT
+  if (ai?.warnings && ai.warnings.length > 0) {
+    const guards = ai.warnings.filter((w) => present(w));
+    if (guards.length) {
+      push('## Guardrails — do NOT');
+      push();
+      for (const w of guards) push(`- ${w}`);
+      push();
+    }
+  }
+
+  // Stack (reference)
   if (data.stack) {
+    const stack: string[] = [];
     for (const [key, value] of Object.entries(data.stack)) {
-      if (filled(value)) {
-        lines.push(`- **${slotLabel(`stack.${key}`)}:** ${value.trim()}`);
-      }
+      if (filled(value)) stack.push(`- **${slotLabel(`stack.${key}`)}:** ${value.trim()}`);
+    }
+    if (stack.length) {
+      push('## Stack');
+      push();
+      for (const s of stack) push(s);
+      push();
     }
   }
 
+  // Human Context (the who/why — background, kept last after the actionable sections)
   if (data.human_context) {
-    lines.push('');
-    lines.push('## Human Context');
-    lines.push('');
+    const hc: string[] = [];
     for (const [key, value] of Object.entries(data.human_context)) {
-      if (filled(value)) {
-        lines.push(`- **${slotLabel(`human_context.${key}`)}:** ${value.trim()}`);
-      }
+      if (filled(value)) hc.push(`- **${slotLabel(`human_context.${key}`)}:** ${value.trim()}`);
+    }
+    if (hc.length) {
+      push('## Human Context');
+      push();
+      for (const h of hc) push(h);
+      push();
     }
   }
 
-  lines.push('');
   return lines.join('\n');
 }
 

--- a/tests/interop/agents.test.ts
+++ b/tests/interop/agents.test.ts
@@ -1,0 +1,81 @@
+/**
+ * interop/agents — the AGENTS.md exporter must render the actionable sections a
+ * good AGENTS.md needs (setup/build · tests · where-things-live · conventions ·
+ * commit · guardrails) by PROJECTING slots the .faf already carries. Two guards:
+ * (1) a future refactor can't silently drop a section; (2) absent slots must NOT
+ * fabricate one.
+ */
+import { describe, test, expect } from 'bun:test';
+import { generateAgentsMd } from '../../src/interop/agents.js';
+
+const FULL: any = {
+  project: { name: 'demo', goal: 'A small API', main_language: 'Python' },
+  stack: { backend: 'FastAPI', package_manager: 'pip' },
+  commands: {
+    install: 'pip install -e ".[dev]"',
+    test: 'python -m pytest tests/ -v',
+  },
+  key_files: ['server.py', 'tests/test_api.py'],
+  ai_instructions: {
+    working_style: { code_first: true, quality_bar: 'zero_errors' },
+    warnings: ['Version must match across all files', 'Delegate parsing to the SDK'],
+  },
+  preferences: { commit_style: 'conventional', response_style: 'concise' },
+  human_context: { who: 'devs' },
+};
+
+describe('generateAgentsMd — actionable sections render from slots', () => {
+  const md = generateAgentsMd(FULL);
+
+  test('§2 Setup & build ← commands (non-test)', () => {
+    expect(md).toContain('## Setup & build');
+    expect(md).toContain('pip install -e ".[dev]"');
+  });
+
+  test('§3 Tests ← commands (test-keyed)', () => {
+    expect(md).toContain('## Run the tests');
+    expect(md).toContain('python -m pytest tests/ -v');
+  });
+
+  test('§4 Where things live ← key_files', () => {
+    expect(md).toContain('## Where things live');
+    expect(md).toContain('`server.py`');
+  });
+
+  test('§5 Conventions ← working_style + preferences', () => {
+    expect(md).toContain('## Conventions');
+    expect(md).toContain('Quality Bar');
+    expect(md).toContain('zero_errors');
+  });
+
+  test('§6 Commit & PR ← preferences.commit_style', () => {
+    expect(md).toContain('## Commit & PR');
+    expect(md).toContain('conventional');
+  });
+
+  test('§7 Guardrails ← ai_instructions.warnings', () => {
+    expect(md).toContain('## Guardrails — do NOT');
+    expect(md).toContain('Version must match across all files');
+  });
+});
+
+describe('generateAgentsMd — no fabrication when slots absent', () => {
+  // Minimal .faf: orientation only. The actionable sections have no source slots.
+  const md = generateAgentsMd({
+    project: { name: 'bare', goal: 'x', main_language: 'Go' },
+  } as any);
+
+  test('orientation still renders', () => {
+    expect(md).toContain('## Project Context');
+    expect(md).toContain('bare');
+  });
+
+  test('absent slots omit their sections (nothing invented)', () => {
+    expect(md).not.toContain('## Setup & build');
+    expect(md).not.toContain('## Run the tests');
+    expect(md).not.toContain('## Where things live');
+    expect(md).not.toContain('## Conventions');
+    expect(md).not.toContain('## Commit & PR');
+    expect(md).not.toContain('## Guardrails');
+  });
+});


### PR DESCRIPTION
## What
`faf export --agents` now renders the actionable sections a good AGENTS.md needs — projected from slots the `.faf` already carries, not just the spine.

## Sections (each `f(slots)`, no schema change)
| § | Section | From slot |
|---|---------|-----------|
| 2 | Setup & build | `commands` (non-test) |
| 3 | Run the tests | `commands` (test-keyed) |
| 4 | Where things live | `key_files` / `instant_context.key_files` |
| 5 | Conventions | `ai_instructions.working_style` + `preferences` |
| 6 | Commit & PR | `preferences.commit_style` |
| 7 | Guardrails | `ai_instructions.warnings` |

Orientation + Stack unchanged. **Human Context kept**, moved to the end as background — agents read AGENTS.md; README stays a human read.

## Honesty (FAF-don't-lie)
No new slots, no schema change, no guessed commands — renders `commands` verbatim if authored; an absent slot omits its section (nothing invented).

## Tests
`tests/interop/agents.test.ts` (8): each section + its values render; anti-fabrication guard (absent slots → no section). Full suite: **1093 pass, 0 fail**.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*
