### PR TITLE
feat: Stage 0 — ready the storefront (star CTA · Homebrew fix · AGENTS.md keywords)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   </div>
 </div>
 
-[![npm version](https://img.shields.io/npm/v/faf-cli)](https://www.npmjs.com/package/faf-cli)[![npm downloads](https://img.shields.io/npm/dt/faf-cli?color=008B8B&label=downloads)](https://www.npmjs.com/package/faf-cli)
+[![GitHub stars](https://img.shields.io/github/stars/Wolfe-Jam/faf-cli?style=social)](https://github.com/Wolfe-Jam/faf-cli)  [![npm version](https://img.shields.io/npm/v/faf-cli)](https://www.npmjs.com/package/faf-cli)[![npm downloads](https://img.shields.io/npm/dt/faf-cli?color=008B8B&label=downloads)](https://www.npmjs.com/package/faf-cli)
 [![FAF Trophy 100%](https://img.shields.io/badge/FAF-%F0%9F%8F%86%20100%25-000000?labelColor=FF6B35)](https://faf.one)
 [![IANA: vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-008B8B)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)[![IANA: vnd.fafm+yaml](https://img.shields.io/badge/IANA-vnd.fafm%2Byaml-008B8B)](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml)
 [![DOI: Context paper](https://img.shields.io/badge/DOI-Context%20paper-FF6B35)](https://doi.org/10.5281/zenodo.18251362)[![DOI: Memory paper](https://img.shields.io/badge/DOI-Memory%20paper-FF6B35)](https://doi.org/10.5281/zenodo.20348942)
@@ -48,7 +48,7 @@ project/
 ```bash
 bunx faf                      # Bun — zero install, fastest path
 npx faf                       # npm — works everywhere
-brew install faf-cli && faf   # Homebrew
+brew install wolfe-jam/faf/faf-cli && faf   # Homebrew (auto-taps)
 ```
 
 > `faf` is shorthand for `faf-cli auto` — same behavior, fewer keystrokes.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,11 @@
     "model-context-protocol",
     "persistent-context",
     "ai-readiness",
-    "foundational"
+    "foundational",
+    "agents-md",
+    "context-engineering",
+    "codex",
+    "windsurf"
   ],
   "author": "wolfejam <wolfejam@faf.one>",
   "license": "MIT",


### PR DESCRIPTION
## Stage 0 — ready the storefront

Small storefront fixes, no code changes.

- **README:** GitHub star affordance on the first-screen badge row (README is the star button; 35k downloads vs a low star count = uncaptured reservoir).
- **README:** Homebrew fixed — `brew install faf-cli` 404s (not in homebrew-core, only the personal tap); corrected to `brew install wolfe-jam/faf/faf-cli` (auto-taps).
- **package.json:** keywords += `agents-md` (The AGENTS.md Edition), `context-engineering`, `codex`, `windsurf`.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*