### PR TITLE
feat: Stage 2 — star-nudge (capture the reservoir)

### DIFF
--- a/src/ui/display.ts
+++ b/src/ui/display.ts
@@ -1,6 +1,7 @@
 import type { ScoreResult, SlotState } from '../core/types.js';
 import { tierBadge } from '../core/tiers.js';
 import { bold, dim, fafCyan, orange } from './colors.js';
+import { maybeStarNudge } from './star-nudge.js';
 
 /** Display a score result to stdout */
 export function displayScore(result: ScoreResult, file: string, verbose = false): void {
@@ -30,6 +31,9 @@ export function displayScore(result: ScoreResult, file: string, verbose = false)
     console.log('');
     displaySlotBreakdown(result);
   }
+
+  // Capture the reservoir: a quiet star ask after a genuine win (gated in star-nudge.ts).
+  maybeStarNudge(result.score);
 }
 
 /** Display individual slot states */

--- a/src/ui/star-nudge.ts
+++ b/src/ui/star-nudge.ts
@@ -1,0 +1,83 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { dim, orange } from './colors.js';
+
+/**
+ * The star-nudge — capture the reservoir. A CLI has orders of magnitude more
+ * users than stars because users never see the repo page; a single quiet ask
+ * after a genuine win converts a slice of that usage into the signal ~3 of 4
+ * developers check before adopting a project (Borges & Valente, JSS 2018).
+ *
+ * Discipline (gravity, not spam): only on a real win, only interactively, NEVER
+ * in CI (most installs are build machines), throttled to once per 30 days per
+ * machine, and silenceable with FAF_NO_NUDGE. Shown at most a handful of times
+ * in a user's life.
+ */
+const WIN_SCORE = 95; // Silver+ — a genuine "your context is excellent" moment
+const THROTTLE_DAYS = 30;
+const STATE_DIR = join(homedir(), '.config', 'faf');
+const STATE_FILE = join(STATE_DIR, 'star-nudge');
+const REPO = 'github.com/Wolfe-Jam/faf-cli';
+
+export interface NudgeContext {
+  score: number;
+  isTTY: boolean;
+  isCI: boolean;
+  optedOut: boolean;
+  lastShownMs: number | null;
+  nowMs: number;
+  throttleDays?: number;
+}
+
+/**
+ * Pure decision — show the nudge only on a genuine win, interactively, never in
+ * CI/opted-out, and not within the throttle window. Kept pure so the gate is
+ * unit-testable without touching the filesystem, the clock, or the TTY.
+ */
+export function shouldNudge(c: NudgeContext): boolean {
+  if (c.score < WIN_SCORE) return false; // only a real win earns the ask
+  if (!c.isTTY) return false; // never when piped/redirected
+  if (c.isCI || c.optedOut) return false; // never in CI; honour opt-out
+  if (c.lastShownMs != null) {
+    const windowMs = (c.throttleDays ?? THROTTLE_DAYS) * 86_400_000;
+    if (c.nowMs - c.lastShownMs < windowMs) return false; // throttled
+  }
+  return true;
+}
+
+function readLastShownMs(): number | null {
+  try {
+    if (!existsSync(STATE_FILE)) return null;
+    const ms = Date.parse(readFileSync(STATE_FILE, 'utf-8').trim());
+    return Number.isFinite(ms) ? ms : null;
+  } catch {
+    return null; // a read error must never block scoring
+  }
+}
+
+function record(nowMs: number): void {
+  try {
+    mkdirSync(STATE_DIR, { recursive: true });
+    writeFileSync(STATE_FILE, new Date(nowMs).toISOString());
+  } catch {
+    /* a nudge must never fail a command */
+  }
+}
+
+/** Emit the one-line star nudge if all gates pass, then record it. Side-effecting wrapper over shouldNudge. */
+export function maybeStarNudge(score: number): void {
+  const nowMs = Date.now();
+  const show = shouldNudge({
+    score,
+    isTTY: Boolean(process.stdout.isTTY),
+    isCI: Boolean(process.env.CI),
+    optedOut: Boolean(process.env.FAF_NO_NUDGE),
+    lastShownMs: readLastShownMs(),
+    nowMs,
+  });
+  if (!show) return;
+  console.log('');
+  console.log(`  ${orange('★')} ${dim('Enjoying faf-cli? A star helps others find it:')} ${REPO}`);
+  record(nowMs);
+}

--- a/src/ui/star-nudge.ts
+++ b/src/ui/star-nudge.ts
@@ -10,12 +10,15 @@ import { dim, orange } from './colors.js';
  * developers check before adopting a project (Borges & Valente, JSS 2018).
  *
  * Discipline (gravity, not spam): only on a real win, only interactively, NEVER
- * in CI (most installs are build machines), throttled to once per 30 days per
- * machine, and silenceable with FAF_NO_NUDGE. Shown at most a handful of times
- * in a user's life.
+ * in CI (most installs are build machines), throttled to once per 30 days, and
+ * CAPPED at a handful of showings for a user's whole life. A local CLI cannot
+ * know whether you already starred — that needs YOUR GitHub token — so rather
+ * than probe your account, it simply stops asking after MAX_SHOWS. Silence it
+ * any time with FAF_NO_NUDGE.
  */
 const WIN_SCORE = 95; // Silver+ — a genuine "your context is excellent" moment
 const THROTTLE_DAYS = 30;
+const MAX_SHOWS = 3; // lifetime cap — retire the nudge after this many, starred or not
 const STATE_DIR = join(homedir(), '.config', 'faf');
 const STATE_FILE = join(STATE_DIR, 'star-nudge');
 const REPO = 'github.com/Wolfe-Jam/faf-cli';
@@ -25,20 +28,23 @@ export interface NudgeContext {
   isTTY: boolean;
   isCI: boolean;
   optedOut: boolean;
+  shownCount: number;
   lastShownMs: number | null;
   nowMs: number;
   throttleDays?: number;
+  maxShows?: number;
 }
 
 /**
- * Pure decision — show the nudge only on a genuine win, interactively, never in
- * CI/opted-out, and not within the throttle window. Kept pure so the gate is
- * unit-testable without touching the filesystem, the clock, or the TTY.
+ * Pure decision — show only on a genuine win, interactively, never in CI/opted
+ * out, not past the lifetime cap, and not within the throttle window. Kept pure
+ * so every gate is unit-testable without the filesystem, the clock, or the TTY.
  */
 export function shouldNudge(c: NudgeContext): boolean {
   if (c.score < WIN_SCORE) return false; // only a real win earns the ask
   if (!c.isTTY) return false; // never when piped/redirected
   if (c.isCI || c.optedOut) return false; // never in CI; honour opt-out
+  if (c.shownCount >= (c.maxShows ?? MAX_SHOWS)) return false; // retired — never nag forever
   if (c.lastShownMs != null) {
     const windowMs = (c.throttleDays ?? THROTTLE_DAYS) * 86_400_000;
     if (c.nowMs - c.lastShownMs < windowMs) return false; // throttled
@@ -46,20 +52,35 @@ export function shouldNudge(c: NudgeContext): boolean {
   return true;
 }
 
-function readLastShownMs(): number | null {
+interface NudgeState {
+  shown: number;
+  lastShownMs: number | null;
+}
+
+function readState(): NudgeState {
   try {
-    if (!existsSync(STATE_FILE)) return null;
-    const ms = Date.parse(readFileSync(STATE_FILE, 'utf-8').trim());
-    return Number.isFinite(ms) ? ms : null;
+    if (!existsSync(STATE_FILE)) return { shown: 0, lastShownMs: null };
+    const raw = readFileSync(STATE_FILE, 'utf-8').trim();
+    if (raw.startsWith('{')) {
+      const j = JSON.parse(raw) as { shown?: number; last?: string };
+      const ms = j.last ? Date.parse(j.last) : NaN;
+      return {
+        shown: Number.isFinite(j.shown as number) ? Number(j.shown) : 0,
+        lastShownMs: Number.isFinite(ms) ? ms : null,
+      };
+    }
+    // Back-compat: the first release wrote a plain ISO string — count it as one showing.
+    const ms = Date.parse(raw);
+    return { shown: 1, lastShownMs: Number.isFinite(ms) ? ms : null };
   } catch {
-    return null; // a read error must never block scoring
+    return { shown: 0, lastShownMs: null }; // a read error must never block scoring
   }
 }
 
-function record(nowMs: number): void {
+function record(prevShown: number, nowMs: number): void {
   try {
     mkdirSync(STATE_DIR, { recursive: true });
-    writeFileSync(STATE_FILE, new Date(nowMs).toISOString());
+    writeFileSync(STATE_FILE, JSON.stringify({ shown: prevShown + 1, last: new Date(nowMs).toISOString() }));
   } catch {
     /* a nudge must never fail a command */
   }
@@ -68,16 +89,18 @@ function record(nowMs: number): void {
 /** Emit the one-line star nudge if all gates pass, then record it. Side-effecting wrapper over shouldNudge. */
 export function maybeStarNudge(score: number): void {
   const nowMs = Date.now();
+  const state = readState();
   const show = shouldNudge({
     score,
     isTTY: Boolean(process.stdout.isTTY),
     isCI: Boolean(process.env.CI),
     optedOut: Boolean(process.env.FAF_NO_NUDGE),
-    lastShownMs: readLastShownMs(),
+    shownCount: state.shown,
+    lastShownMs: state.lastShownMs,
     nowMs,
   });
   if (!show) return;
   console.log('');
   console.log(`  ${orange('★')} ${dim('Enjoying faf-cli? A star helps others find it:')} ${REPO}`);
-  record(nowMs);
+  record(state.shown, nowMs);
 }

--- a/tests/ui/star-nudge.test.ts
+++ b/tests/ui/star-nudge.test.ts
@@ -14,6 +14,7 @@ const ctx = (o: Partial<NudgeContext> = {}): NudgeContext => ({
   isTTY: true,
   isCI: false,
   optedOut: false,
+  shownCount: 0,
   lastShownMs: null,
   nowMs: NOW,
   ...o,
@@ -56,5 +57,21 @@ describe('shouldNudge — throttle window', () => {
   test('custom throttleDays honoured', () => {
     expect(shouldNudge(ctx({ lastShownMs: NOW - 5 * DAY, throttleDays: 3 }))).toBe(true);
     expect(shouldNudge(ctx({ lastShownMs: NOW - 2 * DAY, throttleDays: 3 }))).toBe(false);
+  });
+});
+
+describe('shouldNudge — lifetime cap (we can\'t detect a star, so we stop asking)', () => {
+  test('under the cap → true', () => {
+    expect(shouldNudge(ctx({ shownCount: 2 }))).toBe(true);
+  });
+  test('at the cap (3) → false (retired)', () => {
+    expect(shouldNudge(ctx({ shownCount: 3 }))).toBe(false);
+  });
+  test('over the cap → false', () => {
+    expect(shouldNudge(ctx({ shownCount: 9 }))).toBe(false);
+  });
+  test('custom maxShows honoured', () => {
+    expect(shouldNudge(ctx({ shownCount: 0, maxShows: 1 }))).toBe(true);
+    expect(shouldNudge(ctx({ shownCount: 1, maxShows: 1 }))).toBe(false);
   });
 });

--- a/tests/ui/star-nudge.test.ts
+++ b/tests/ui/star-nudge.test.ts
@@ -1,0 +1,60 @@
+/**
+ * ui/star-nudge — the gate must be conservative: fire ONLY on a genuine win,
+ * interactively, never in CI, never when opted out, and not within the 30-day
+ * throttle. Every guard is tested from both sides. The pure `shouldNudge`
+ * decision carries all the logic (the IO wrapper just feeds it real values).
+ */
+import { describe, test, expect } from 'bun:test';
+import { shouldNudge, type NudgeContext } from '../../src/ui/star-nudge.js';
+
+const NOW = 1_700_000_000_000;
+const DAY = 86_400_000;
+const ctx = (o: Partial<NudgeContext> = {}): NudgeContext => ({
+  score: 100,
+  isTTY: true,
+  isCI: false,
+  optedOut: false,
+  lastShownMs: null,
+  nowMs: NOW,
+  ...o,
+});
+
+describe('shouldNudge — fires on a genuine win', () => {
+  test('win + interactive + not-CI + never-shown → true', () => {
+    expect(shouldNudge(ctx())).toBe(true);
+  });
+  test('score 95 (Silver, the threshold) → true', () => {
+    expect(shouldNudge(ctx({ score: 95 }))).toBe(true);
+  });
+});
+
+describe('shouldNudge — every guard blocks it', () => {
+  test('below the win threshold (94) → false', () => {
+    expect(shouldNudge(ctx({ score: 94 }))).toBe(false);
+  });
+  test('not a TTY (piped/redirected) → false', () => {
+    expect(shouldNudge(ctx({ isTTY: false }))).toBe(false);
+  });
+  test('CI → false (never nudge a build machine)', () => {
+    expect(shouldNudge(ctx({ isCI: true }))).toBe(false);
+  });
+  test('opted out (FAF_NO_NUDGE) → false', () => {
+    expect(shouldNudge(ctx({ optedOut: true }))).toBe(false);
+  });
+});
+
+describe('shouldNudge — throttle window', () => {
+  test('shown 10 days ago (< 30) → false', () => {
+    expect(shouldNudge(ctx({ lastShownMs: NOW - 10 * DAY }))).toBe(false);
+  });
+  test('shown 40 days ago (> 30) → true', () => {
+    expect(shouldNudge(ctx({ lastShownMs: NOW - 40 * DAY }))).toBe(true);
+  });
+  test('never shown (null) → true', () => {
+    expect(shouldNudge(ctx({ lastShownMs: null }))).toBe(true);
+  });
+  test('custom throttleDays honoured', () => {
+    expect(shouldNudge(ctx({ lastShownMs: NOW - 5 * DAY, throttleDays: 3 }))).toBe(true);
+    expect(shouldNudge(ctx({ lastShownMs: NOW - 2 * DAY, throttleDays: 3 }))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Stage 2 — capture the reservoir

faf-cli has ~35k downloads and few stars because CLI users never see the repo page. This adds one quiet star ask after a genuine win — converting a slice of existing usage into the signal ~3 of 4 developers check before adopting (Borges & Valente, JSS 2018, N=791).

**Discipline (gravity, not spam):**
- Only on a real win — score >= 95 (Silver+).
- Interactive TTY only — never when piped/redirected.
- **Never in CI** (most installs are build machines).
- Throttled to **once per 30 days per machine** (`~/.config/faf/star-nudge`).
- Opt out any time with `FAF_NO_NUDGE`.

Shown at most a handful of times in a user's life. The gate is a pure `shouldNudge()` (10 unit tests); the IO wrapper feeds it real TTY/CI/env/clock values.

**Tune knobs (your call):** win threshold (95), throttle (30d), wording.

— *Assisted by Claude (Opus 4.8) · Approved by James Wolfe (@Wolfe-Jam)*