### PR TITLE
fix: cloning progress → stderr so `faf git --stdout` emits a clean .faf

### DIFF
--- a/src/commands/git.ts
+++ b/src/commands/git.ts
@@ -124,7 +124,8 @@ export function gitCommand(
   mkdirSync(tmpDir, { recursive: true });
 
   try {
-    console.log(dim(`cloning ${url}${options.ref ? ` @ ${options.ref}` : ''}...`));
+    // Progress → stderr, so `--stdout` (piped .faf) never gets an ANSI-contaminated first line.
+    console.error(dim(`cloning ${url}${options.ref ? ` @ ${options.ref}` : ''}...`));
     try {
       // execFileSync runs git directly — NO shell — so the URL can never be
       // interpreted as a command.

--- a/tests/commands/git.test.ts
+++ b/tests/commands/git.test.ts
@@ -90,6 +90,27 @@ describe('TYRE: git command', () => {
     expect(allErr).toContain('this-host-does-not-exist.invalid');
   });
 
+  test('gitCommand() prints "cloning" progress to stderr, never stdout (keeps --stdout clean)', async () => {
+    const { gitCommand } = await import('../../src/commands/git.js');
+    const errs: string[] = [];
+    const logs: string[] = [];
+    const errSpy = spyOn(console, 'error').mockImplementation((s: string) => { errs.push(s); });
+    const logSpy = spyOn(console, 'log').mockImplementation((s: string) => { logs.push(s); });
+    const exitSpy = spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}__`);
+    }) as never);
+    try {
+      // .invalid fails fast (no network) — but the progress line prints BEFORE the clone,
+      // so we still capture which stream it took. --stdout reserves stdout for the .faf.
+      gitCommand('https://this-host-does-not-exist.invalid/never/ever', { stdout: true });
+    } catch { /* exits on clone failure — expected; the progress line already printed */ }
+    errSpy.mockRestore();
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+    expect(errs.join('\n')).toMatch(/cloning/);       // progress → stderr
+    expect(logs.join('\n')).not.toMatch(/cloning/);   // never → stdout (that leak was the bug)
+  });
+
   test('gitCommand() with malformed URL → exits 1 (not a process crash)', async () => {
     const { gitCommand } = await import('../../src/commands/git.js');
     const errSpy = spyOn(console, 'error').mockImplementation(() => {});


### PR DESCRIPTION
A complete fix that was sitting uncommitted since the 7.0 ship.

**Bug:** in `--stdout` mode, `faf git owner/repo --stdout` pipes the `.faf` to stdout — but the `"cloning..."` progress line *also* went to stdout (`console.log`), so `faf git repo --stdout > out.faf` corrupted the `.faf`s **first line** with an ANSI-dimmed string.

**Fix (1 line):** progress → `console.error` (stderr), where it belongs. stdout is reserved for the `.faf`.

**Test:** a WJTTC **TYRE**-tier test asserting `"cloning"` appears in **stderr** and **never stdout** — the exact leak. Uses a `.invalid` host so it fails fast with no network; the progress line prints before the clone attempt. ✅ verified green locally.

Patch-level; rides the next faf-cli publish.