### PR TITLE
docs: FAF authors context — generate→author copy sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # faf-cli
 
-### The context every AI coding agent reads — generated from your repo, never guessed.
+### The context every AI coding agent reads — authored from your repo, never guessed.
 
 **One `.faf` file → `AGENTS.md` · `CLAUDE.md` · `GEMINI.md` · `.cursorrules`,<br>
 detected from your real stack, scored, and versioned with your code. No drift. No re-explaining.**
@@ -79,7 +79,7 @@ Run `faf` with no arguments:
 
 ## v7.1 — The AGENTS.md Edition
 
-**`faf export --agents` now generates a complete, best-in-class AGENTS.md for any repo — detected from your code, non-destructive, never stale.**
+**`faf export --agents` now authors a complete, best-in-class AGENTS.md for any repo — detected from your code, non-destructive, never stale.**
 
 Point it at any repo and it detects your build/test commands, key files, conventions (ESLint/Prettier/strict/ruff/mypy…), and guardrails — then writes the definitive AGENTS.md: orientation, setup, tests, where-things-live, conventions, three-tier guardrails, a Definition of Done composed from your real commands, and secrets handling. Facts, not bloat. Your hand-written content is preserved.
 
@@ -91,7 +91,7 @@ npx faf-cli export --agents
 
 ## Context for AI agents
 
-FAF-CLI generates the files agents read (AGENTS.md, CLAUDE.md, .cursorrules) from real project detection — zero-install via `bunx faf`.
+FAF-CLI authors the files agents read (AGENTS.md, CLAUDE.md, .cursorrules) from real project detection — zero-install via `bunx faf`.
 
 - [→ FAF-CLI for Grok, xAI & Cursor 👀](docs/faf-cli-for-agents.md)
 - [→ FAF-CLI for Claude Code 👀](docs/faf-cli-for-claude.md)
@@ -300,12 +300,12 @@ The WASM scoring kernel (`faf-scoring-kernel` 2.0.0) does the math. Bun does the
 | 6 | `faf sync` | `.faf` ↔ CLAUDE.md (bi-sync, mtime auto-direction) |
 | 7 | `faf compile` | `.faf` → `.fafb` binary — sealed, portable, deterministic |
 | 8 | `faf decompile` | `.fafb` → JSON |
-| 9 | `faf export` | Generate AGENTS.md, .cursorrules, GEMINI.md |
+| 9 | `faf export` | Author AGENTS.md, .cursorrules, GEMINI.md |
 | 10 | `faf check` | Validate `.faf` file |
 | 11 | `faf edit` | Edit `.faf` fields inline |
 | 12 | `faf convert` | Convert `.faf` to JSON |
 | 13 | `faf drift` | Check context drift |
-| 14 | `faf context` | Generate context output |
+| 14 | `faf context` | Author context output |
 | 15 | `faf recover` | Recover `.faf` from CLAUDE.md / AGENTS.md |
 | 16 | `faf migrate` | Migrate `.faf` to latest version |
 | 17 | `faf search` | Search slots and formats |

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -159,7 +159,7 @@ faf auto                    # Auto-enhance to Gold Code
 ```
 
 ### Exploring Repos
-**Instantly.** Generate context for ANY GitHub repo WITHOUT cloning:
+**Instantly.** Author context for ANY GitHub repo WITHOUT cloning:
 ```bash
 bunx faf-cli git https://github.com/facebook/react
 # 2 seconds → 95% ◆ Silver score

--- a/docs/faf-cli-for-agents.md
+++ b/docs/faf-cli-for-agents.md
@@ -2,7 +2,7 @@
 
 **One command. Every agent in your session gets the same accurate, versioned context.**
 
-FAF-CLI (v7.1, "The AGENTS.md Edition") is the canonical tool for the [`.faf` format](https://faf.one): persistent, versioned, AI-readable project context. It generates exactly the instruction files agentic tools are built to read — `AGENTS.md`, `.cursorrules`, `CLAUDE.md`, `GEMINI.md`, `copilot-instructions.md` — from a single source of truth, and exposes live tools over MCP. Part of the FAF ecosystem — [100,000+ downloads](https://faf.one/blog/hundred-thousand).
+FAF-CLI (v7.1, "The AGENTS.md Edition") is the canonical tool for the [`.faf` format](https://faf.one): persistent, versioned, AI-readable project context. It authors exactly the instruction files agentic tools are built to read — `AGENTS.md`, `.cursorrules`, `CLAUDE.md`, `GEMINI.md`, `copilot-instructions.md` — from a single source of truth, and exposes live tools over MCP. Part of the FAF ecosystem — [100,000+ downloads](https://faf.one/blog/hundred-thousand).
 
 ---
 
@@ -40,7 +40,7 @@ xAI ships strong agentic capabilities — native tool use, the Agent Tools API, 
 
 ## For Cursor multi-agent workflows
 
-Cursor's Composer and background agents rely on exactly the files FAF generates:
+Cursor's Composer and background agents rely on exactly the files FAF authors:
 
 1. **Better context files** — `faf export --agents` produces higher-fidelity `AGENTS.md` / `.cursorrules` than hand-rolled versions, because it scans for real build commands, conventions, guardrails, and Definition of Done.
 2. **Non-destructive + bi-sync** — keep editing the parts you care about; FAF keeps the structured block current.

--- a/docs/faf-cli-for-bun.md
+++ b/docs/faf-cli-for-bun.md
@@ -25,7 +25,7 @@ FAF is Bun-aware end to end — it reads your project the way Bun sees it:
 
 1. **Runs through `bunx`** — zero-install, always the latest release, no global state to manage.
 2. **Detects your Bun runtime** — faf recognizes `bunfig.toml` and `bun.lock` / `bun.lockb` and reports **Bun** as the runtime and package manager, not a generic Node guess.
-3. **Emits bun-based commands** — when faf sees a Bun lockfile it prefers `bun` as the runner, so the generated `AGENTS.md` carries `bun install` / `bun test` / `bun run` — the commands your project actually uses.
+3. **Emits bun-based commands** — when faf sees a Bun lockfile it prefers `bun` as the runner, so the authored `AGENTS.md` carries `bun install` / `bun test` / `bun run` — the commands your project actually uses.
 4. **Same toolchain** — faf-cli is bundled with `bun build`; you're running a tool built on the runtime you ship on.
 
 ## Why context matters on a fast stack

--- a/docs/faf-cli-for-claude.md
+++ b/docs/faf-cli-for-claude.md
@@ -27,7 +27,7 @@ CLAUDE.md    → prose for Claude
 project.faf  → structure for any AI  ← the scored source the others project from
 ```
 
-`CLAUDE.md` is Claude's instruction file. `project.faf` is the structured, scored source it's generated from — so instead of hand-maintaining prose that rots the moment the stack changes, you maintain one source and let FAF keep `CLAUDE.md` current.
+`CLAUDE.md` is Claude's instruction file. `project.faf` is the structured, scored source it's authored from — so instead of hand-maintaining prose that rots the moment the stack changes, you maintain one source and let FAF keep `CLAUDE.md` current.
 
 ## Why this fits Claude Code
 
@@ -51,7 +51,7 @@ Static files are the baseline; [claude-faf-mcp](https://www.npmjs.com/package/cl
 
 ## Why it's a natural fit
 
-FAF-CLI isn't another AI wrapper — it's the canonical, versioned, stack-aware source that `CLAUDE.md` should be generated *from*. The bi-sync means the file Claude reads can't quietly fall out of date, and the MCP server means Claude can act on live context, not just a snapshot. One command (`bunx faf`) turns any project into one Claude can actually understand — measurable, versioned, and consistent.
+FAF-CLI isn't another AI wrapper — it's the canonical, versioned, stack-aware source that `CLAUDE.md` should be authored *from*. The bi-sync means the file Claude reads can't quietly fall out of date, and the MCP server means Claude can act on live context, not just a snapshot. One command (`bunx faf`) turns any project into one Claude can actually understand — measurable, versioned, and consistent.
 
 ---
 


### PR DESCRIPTION
## What

Copy-sweep across user-facing prose: replaced the **generate** word-family with the **author** family — but ONLY where it describes what FAF / the FAF tool **authors** as output. FAF authors context (reads repo → discerns → authors from intel); it never "generates" it.

## Changed (11 edits, README + docs prose)

- `README.md`
  - Hero tagline: "reads — ~~generated~~ **authored** from your repo"
  - v7.1 highlight: "`faf export --agents` now ~~generates~~ **authors** a complete… AGENTS.md"
  - "FAF-CLI ~~generates~~ **authors** the files agents read…"
  - Command table: "~~Generate~~ **Author** AGENTS.md, .cursorrules, GEMINI.md" · "~~Generate~~ **Author** context output"
- `docs/faf-cli-for-agents.md` — "It ~~generates~~ **authors** exactly the instruction files…" · "…rely on exactly the files FAF ~~generates~~ **authors**:"
- `docs/faf-cli-for-bun.md` — "so the ~~generated~~ **authored** `AGENTS.md` carries…"
- `docs/faf-cli-for-claude.md` — "the scored source it's ~~generated~~ **authored** from" · "…source that `CLAUDE.md` should be ~~generated~~ **authored** *from*."
- `docs/GUIDE.md` — "**Instantly.** ~~Generate~~ **Author** context for ANY GitHub repo…"

## Deliberately left (conservative — under-change, never over-change)

- Code identifiers / fields: `generateProjectHtml`, the `generated` honest-first emit field
- Third-party name: Google `generative-ai-cli`
- Coined term `context-generated` (never changed)
- Pejorative `auto-generate`/`AI-generated` LLM-slop framing
- Test-receipt verbs: "Generate TAF test receipt" (a record, not authored context)
- Literal commands inside fenced code blocks (`# generate AGENTS.md` comments, `faf bi-sync --agents`)
- Historical `CHANGELOG.md` release entries (dated record — two context-prose hits at L20 & L1138 left as historical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)