### PR TITLE
fix: single source of truth for faf_version (kill 2.5.0 drift)

### DIFF
--- a/src/commands/conductor.ts
+++ b/src/commands/conductor.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync, readdirSync } from 'fs';
 import { join, basename } from 'path';
 import { findFafFile, readFaf, writeFaf } from '../interop/faf.js';
+import { FAF_VERSION } from '../core/version.js';
 import { parse } from 'yaml';
 import { fafCyan, dim, bold } from '../ui/colors.js';
 import type { FafData } from '../core/types.js';
@@ -29,7 +30,7 @@ function conductorImport(configPath?: string): void {
     process.exit(2);
   }
 
-  const data: FafData = { faf_version: '2.5.0', project: {} };
+  const data: FafData = { faf_version: FAF_VERSION, project: {} };
 
   // Try to read YAML/JSON files from the config directory or file
   if (existsSync(configPath) && configPath.endsWith('.json')) {

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -1,8 +1,9 @@
 import { findFafFile, readFaf, writeFaf } from '../interop/faf.js';
 import { SLOTS } from '../core/slots.js';
 import { fafCyan, dim, bold } from '../ui/colors.js';
+import { FAF_VERSION } from '../core/version.js';
 
-const CURRENT_VERSION = '2.5.0';
+const CURRENT_VERSION = FAF_VERSION;
 
 export interface MigrateOptions {
   dryRun?: boolean;

--- a/src/commands/recover.ts
+++ b/src/commands/recover.ts
@@ -4,12 +4,13 @@ import { findFafFile, readFaf, writeFaf } from '../interop/faf.js';
 import { parseClaudeMd } from '../interop/claude.js';
 import { fafCyan, dim, bold } from '../ui/colors.js';
 import type { FafData } from '../core/types.js';
+import { FAF_VERSION } from '../core/version.js';
 
 /** Recover .faf from context files (CLAUDE.md, AGENTS.md, GEMINI.md, .cursorrules) */
 export function recoverCommand(): void {
   const dir = process.cwd();
   const sources: string[] = [];
-  const data: FafData = { faf_version: '2.5.0', project: {} };
+  const data: FafData = { faf_version: FAF_VERSION, project: {} };
 
   // Try CLAUDE.md first (richest source)
   const claudePath = join(dir, 'CLAUDE.md');

--- a/src/core/version.ts
+++ b/src/core/version.ts
@@ -1,0 +1,10 @@
+/**
+ * The `.faf` format series a freshly written file is stamped with — the single
+ * source of truth for `faf_version`.
+ *
+ * Everything that authors a new `.faf` (detect, recover, conductor) and the
+ * `migrate` target reads it from here, so the version can never drift file-to-
+ * file again. (That drift is exactly what left those paths stranded on the old
+ * `2.5.0` while the ecosystem moved to the `3.0` series.)
+ */
+export const FAF_VERSION = '3.0';

--- a/src/detect/stack.ts
+++ b/src/detect/stack.ts
@@ -1,5 +1,6 @@
 import type { FafData } from '../core/types.js';
 import { APP_TYPE_CATEGORIES, SLOTS } from '../core/slots.js';
+import { FAF_VERSION } from '../core/version.js';
 import {
   detectFrameworks,
   detectLanguage,
@@ -147,7 +148,7 @@ export function detectStack(dir: string): FafData {
   const commands = detectCommands(dir, pkg);
 
   const result: FafData = {
-    faf_version: '2.5.0',
+    faf_version: FAF_VERSION,
     project,
     stack,
     human_context: {

--- a/tests/commands/auto.test.ts
+++ b/tests/commands/auto.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { parse } from 'yaml';
+import { FAF_VERSION } from '../../src/core/version.js';
 
 describe('TYRE: auto command', () => {
   let testDir: string;
@@ -28,7 +29,7 @@ describe('TYRE: auto command', () => {
 
     expect(existsSync(join(testDir, 'project.faf'))).toBe(true);
     const content = parse(readFileSync(join(testDir, 'project.faf'), 'utf-8'));
-    expect(content.faf_version).toBe('2.5.0');
+    expect(content.faf_version).toBe(FAF_VERSION);
   });
 
   test('merges into existing project.faf', () => {

--- a/tests/commands/git.test.ts
+++ b/tests/commands/git.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { execSync } from 'child_process';
 import { detectStack } from '../../src/detect/stack.js';
+import { FAF_VERSION } from '../../src/core/version.js';
 import { parse } from 'yaml';
 
 describe('TYRE: git command', () => {
@@ -31,12 +32,12 @@ describe('TYRE: git command', () => {
 
     const data = detectStack(testDir);
     expect(data.project?.name).toBe('git-test-app');
-    expect(data.faf_version).toBe('2.5.0');
+    expect(data.faf_version).toBe(FAF_VERSION);
   });
 
   test('detectStack handles empty directory', () => {
     const data = detectStack(testDir);
-    expect(data.faf_version).toBe('2.5.0');
+    expect(data.faf_version).toBe(FAF_VERSION);
     expect(data.project).toBeDefined();
   });
 

--- a/tests/commands/migrate.test.ts
+++ b/tests/commands/migrate.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync, writeFileSync, rmSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { parse } from 'yaml';
+import { FAF_VERSION } from '../../src/core/version.js';
 
 describe('TYRE: migrate command', () => {
   let testDir: string;
@@ -20,14 +21,14 @@ describe('TYRE: migrate command', () => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  test('migrates old version to 2.5.0', () => {
+  test('migrates old version to current', () => {
     writeFileSync(join(testDir, 'project.faf'), `faf_version: 1.0.0\nproject:\n  name: test\n`);
 
     const { migrateCommand } = require('../../src/commands/migrate.js');
     migrateCommand();
 
     const content = parse(readFileSync(join(testDir, 'project.faf'), 'utf-8'));
-    expect(content.faf_version).toBe('2.5.0');
+    expect(content.faf_version).toBe(FAF_VERSION);
     expect(content.project.name).toBe('test');
     expect(content.stack).toBeDefined();
     expect(content.human_context).toBeDefined();
@@ -35,15 +36,15 @@ describe('TYRE: migrate command', () => {
   });
 
   test('already at current version is no-op', () => {
-    const original = `faf_version: 2.5.0\nproject:\n  name: test\n`;
+    const original = `faf_version: ${FAF_VERSION}\nproject:\n  name: test\n`;
     writeFileSync(join(testDir, 'project.faf'), original);
 
     const { migrateCommand } = require('../../src/commands/migrate.js');
     migrateCommand();
 
-    // File should be unchanged (or at least still 2.5.0)
+    // File should be unchanged (or at least still at the current version)
     const content = parse(readFileSync(join(testDir, 'project.faf'), 'utf-8'));
-    expect(content.faf_version).toBe('2.5.0');
+    expect(content.faf_version).toBe(FAF_VERSION);
   });
 
   test('dry run does not modify file', () => {

--- a/tests/detect/WJTTC-svelte.test.ts
+++ b/tests/detect/WJTTC-svelte.test.ts
@@ -26,6 +26,7 @@ import {
   detectCicd,
 } from '../../src/detect/scanner.js';
 import { detectStack } from '../../src/detect/stack.js';
+import { FAF_VERSION } from '../../src/core/version.js';
 import { APP_TYPE_CATEGORIES } from '../../src/core/slots.js';
 import { FRAMEWORKS } from '../../src/detect/frameworks.js';
 
@@ -119,7 +120,7 @@ describe('🛑 BRAKE TIER - Svelte Detection Critical Path', () => {
     expect(data.stack).toBeDefined();
     expect(data.human_context).toBeDefined();
     expect(data.monorepo).toBeDefined();
-    expect(data.faf_version).toBe('2.5.0');
+    expect(data.faf_version).toBe(FAF_VERSION);
   });
 
   test('BRAKE-S007: Svelte project type must set project.type to svelte', () => {

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { parse } from 'yaml';
 import { execSync } from 'child_process';
+import { FAF_VERSION } from '../src/core/version.js';
 
 /**
  * Full end-to-end test: exercises the entire CLI flow as a user would.
@@ -42,7 +43,7 @@ describe('TYRE: faf e2e — full lifecycle', () => {
     run('init --yolo');
     expect(existsSync(join(testDir, 'project.faf'))).toBe(true);
     const faf = parse(readFileSync(join(testDir, 'project.faf'), 'utf-8'));
-    expect(faf.faf_version).toBe('2.5.0');
+    expect(faf.faf_version).toBe(FAF_VERSION);
     expect(faf.project.name).toBe('e2e-test-app');
   });
 
@@ -50,7 +51,7 @@ describe('TYRE: faf e2e — full lifecycle', () => {
     run('auto');
     const faf = parse(readFileSync(join(testDir, 'project.faf'), 'utf-8'));
     expect(faf.project.name).toBe('e2e-test-app');
-    expect(faf.faf_version).toBe('2.5.0');
+    expect(faf.faf_version).toBe(FAF_VERSION);
   });
 
   // --- Phase 2: Score & Validate ---


### PR DESCRIPTION
## What

`faf_version` was hard-coded as `'2.5.0'` in **four separate writers** — `detect/stack.ts`, `recover.ts`, `conductor.ts`, and `migrate.ts` — and had drifted stale while the format series moved to **3.0**. Scattered version literals that drift is the exact anti-pattern FAF exists to kill, so this fixes it with FAF's own principle: **one source of truth**.

## Changes

- **New `src/core/version.ts`** — `export const FAF_VERSION = '3.0'`, the single stamp every writer reads. The version can never drift file-to-file again.
- Wired all four writers (+ `migrate`'s `CURRENT_VERSION`) to the const.
- Re-pointed the **writer-output** test assertions from `.toBe('2.5.0')` → `.toBe(FAF_VERSION)`, so tests track the source and can't re-pin a stale literal on the next bump. Input fixtures that seed older versions are left untouched — they prove we still read pre-3.0 files.

## Verification

- `tsc --noEmit` clean
- Full suite: **1146 pass, 0 fail** (includes score + e2e lifecycle)
- Real-binary smoke: fresh `faf init` stamps `faf_version: "3.0"`
- Scoring is **version-independent** — 3.0 scores identically to 2.5.0, so no scoring impact.
