### PR TITLE
feat(cli): FAF authors context — CLI status output Generated→Authored

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -175,15 +175,15 @@ program
 program
   .command('export')
   .description('Export context files from .faf')
-  .option('--agents', 'Generate AGENTS.md')
-  .option('--cursor', 'Generate .cursorrules')
-  .option('--gemini', 'Generate GEMINI.md')
-  .option('--copilot', 'Generate .github/copilot-instructions.md (GitHub Copilot)')
+  .option('--agents', 'Author AGENTS.md')
+  .option('--cursor', 'Author .cursorrules')
+  .option('--gemini', 'Author GEMINI.md')
+  .option('--copilot', 'Author .github/copilot-instructions.md (GitHub Copilot)')
   .option('--grok', 'Wire grok-faf-mcp into .grok/config.toml')
-  .option('--conductor', 'Generate conductor config')
-  .option('--html', 'Generate project.html (visual render of project.faf)')
-  .option('--card', 'Generate MCP Server Card (.well-known/mcp/server-card) with the FAF context-block')
-  .option('--all', 'Generate all formats')
+  .option('--conductor', 'Author conductor config')
+  .option('--html', 'Author project.html (visual render of project.faf)')
+  .option('--card', 'Author MCP Server Card (.well-known/mcp/server-card) with the FAF context-block')
+  .option('--all', 'Author all formats')
   .action((options) => exportCommand(options));
 
 program
@@ -235,7 +235,7 @@ program
 
 program
   .command('context')
-  .description('Generate context output')
+  .description('Author context output')
   .action(() => contextCommand());
 
 program

--- a/src/commands/conductor.ts
+++ b/src/commands/conductor.ts
@@ -14,7 +14,7 @@ export function conductorCommand(subcommand?: string, path?: string): void {
   } else {
     console.log(`${fafCyan('conductor')} ${dim('— conductor integration')}\n`);
     console.log(`  ${bold('faf conductor import <path>')} ${dim('— import conductor config into .faf')}`);
-    console.log(`  ${bold('faf conductor export')} ${dim('— generate conductor config from .faf')}`);
+    console.log(`  ${bold('faf conductor export')} ${dim('— author conductor config from .faf')}`);
   }
 }
 


### PR DESCRIPTION
## What

FAF **authors** context, it doesn't generate it. This moves the remaining user-facing "generate"-family strings the CLI prints to the terminal over to the "author" family, tense/case-matched (Generate→Author).

### Output strings changed (all user-facing)
`src/cli.ts` — `faf export` format-flag help descriptions (shown in `faf export --help`):
- `--agents` · `--cursor` · `--gemini` · `--copilot` · `--conductor` · `--html` · `--card` · `--all`: `Generate …` → `Author …`
- `context` command `.description`: `Generate context output` → `Author context output`

`src/commands/conductor.ts` — bare `faf conductor` usage line:
- `— generate conductor config from .faf` → `— author conductor config from .faf`

### Deliberately KEPT (not printed / not the target)
- The `--generated <iso>` CLI flag and its description (references the `generated` `_meta`/JSON **data field**).
- `generateXxx` code identifiers / function names, internal comments, the coined term `context-generated`.
- The status/success **write-lines** already used non-"generate" verbs (`created` / `exported` / `authored` — emitter banners moved to "Authored" in prior work), so no `✓ Generated …` status line remained to change.

## Tests
No test asserted on the old strings (the "Generated" status line doesn't exist; test *descriptions* using "generates" are behavior names, not output assertions), so no assertions needed updating. Full suite green: **1146 pass, 0 fail**. Typecheck (`tsc -p tsconfig.build.json`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)