### PR TITLE
fix(types): migrate bun-types → @types/bun, unmask + fix 2 git.ts type errors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@faf/specification": "github:Wolfe-Jam/faf",
+        "@types/bun": "^1.3.14",
         "@types/node": "^22.15.0",
         "@typescript-eslint/eslint-plugin": "^8.41.0",
         "@typescript-eslint/parser": "^8.41.0",
@@ -59,6 +60,8 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -98,6 +101,8 @@
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@faf/specification": "github:Wolfe-Jam/faf",
+        "@types/bun": "^1.3.14",
         "@types/node": "^22.15.0",
         "@typescript-eslint/eslint-plugin": "^8.41.0",
         "@typescript-eslint/parser": "^8.41.0",
@@ -340,6 +341,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@types/bun": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz",
+      "integrity": "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bun-types": "1.3.14"
       }
     },
     "node_modules/@types/estree": {
@@ -690,6 +701,16 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bun-types": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz",
+      "integrity": "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/bundle-name": {

--- a/package.json
+++ b/package.json
@@ -76,10 +76,11 @@
   },
   "devDependencies": {
     "@faf/specification": "github:Wolfe-Jam/faf",
-    "ajv": "^8.17.1",
+    "@types/bun": "^1.3.14",
     "@types/node": "^22.15.0",
     "@typescript-eslint/eslint-plugin": "^8.41.0",
     "@typescript-eslint/parser": "^8.41.0",
+    "ajv": "^8.17.1",
     "eslint": "^9.39.2",
     "prettier": "^3.2.5",
     "typescript": "^5.3.3",

--- a/src/commands/git.ts
+++ b/src/commands/git.ts
@@ -3,6 +3,7 @@ import { join, resolve } from 'path';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import { assembleFreshFaf } from '../detect/assemble.js';
+import type { FafData } from '../core/types.js';
 import { writeFaf, readFafRaw, serializeFaf } from '../interop/faf.js';
 import * as kernel from '../wasm/kernel.js';
 import { enrichScore } from '../core/scorer.js';
@@ -139,7 +140,9 @@ export function gitCommand(
     }
 
     // Full slot-filling pipeline (shared with `faf auto`) — not detectStack alone.
-    const data = assembleFreshFaf(tmpDir);
+    // assembleFreshFaf returns the loose Record; narrow to FafData here since we
+    // read/write project.name below (the only caller that does).
+    const data = assembleFreshFaf(tmpDir) as FafData;
 
     // Name the project after the REPO, not the throwaway clone dir. Only override
     // the temp-dir fallback — keep a real name assembleFreshFaf found (package.json).

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["bun-types"]
+    "types": ["bun"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "tests"]


### PR DESCRIPTION
## Problem
`tsconfig.json` pinned `"types": ["bun-types"]` but `bun-types` was never a declared dependency, so `tsc --noEmit` (and IDE typechecks) threw **TS2688: Cannot find type definition file for 'bun-types'** on every fresh checkout. Bun's *build* skips `tsc`, so CI stayed green while the manual typecheck was permanently broken — and TS2688 aborting the check **masked 2 real type errors**.

## Fix
- **Migrate off the deprecated package** — Bun 1.3 uses `@types/bun`. Installed `@types/bun@1.3.14`; tsconfig `"bun-types"` → `"bun"`.
- **Fix the 2 unmasked errors** in `src/commands/git.ts` (`data.project.name` on a `{}`-narrowed value) — narrow `assembleFreshFaf`'s loose `Record<string, unknown>` return to `FafData` at the one call site that reads `project.name` (localized; changing the function's return type would break `auto.ts`'s `writeFaf` call).
- **Resync `package-lock.json`** so the L7 `bun.lock`↔`package-lock.json` parity test stays green (`bun add` only touches `bun.lock`).

## Verification
- `tsc --noEmit` → **EXIT 0** (was TS2688 + 2 hidden errors)
- `bun test` → **1146 pass / 0 fail**
- `bun run build` → OK; built output **unchanged** (type-only source change)

No version bump / publish needed — devDep + tsconfig + type-only change; published runtime is identical.