### PR TITLE
fix(cards): emit application/a2a-agent-card+json for the catalog A2A row

### DIFF
--- a/src/interop/cards.ts
+++ b/src/interop/cards.ts
@@ -257,7 +257,7 @@ export function catalogEntriesFor(
     entries.push({
       identifier: `urn:air:${host}:a2a:${slug}`,
       displayName: String(agent.displayName ?? agent.name ?? 'A2A Agent Card'),
-      type: 'application/json',
+      type: 'application/a2a-agent-card+json',
       description: 'A2A v1.0 Agent Card. Projected from .fafa.',
       url: catalogA2AUrl(fafa, opts),
       updatedAt: now,
@@ -292,10 +292,15 @@ function homepageWellKnown(fafa: FafaDoc, name: string): string | undefined {
 function catalogMatchIndex(entries: CatalogEntry[], row: CatalogEntry): number {
   const exact = entries.findIndex((e) => e.identifier === row.identifier);
   if (exact >= 0) {return exact;}
-  if (row.type === 'application/json' || row.identifier.includes(':a2a:')) {
+  if (
+    row.type === 'application/a2a-agent-card+json' ||
+    row.type === 'application/json' ||
+    row.identifier.includes(':a2a:')
+  ) {
     return entries.findIndex(
       (e) =>
         e.identifier.includes(':a2a:') ||
+        e.type === 'application/a2a-agent-card+json' ||
         String(e.url ?? '').includes('agent-card.json'),
     );
   }

--- a/tests/interop/cards.test.ts
+++ b/tests/interop/cards.test.ts
@@ -169,7 +169,7 @@ describe('ENGINE: 🛡️ one projector — faf cards', () => {
     const next = upsertCatalog(existing, p.catalog!);
     const a2a = next.entries.find((e) => e.identifier === 'urn:air:faf.one:a2a:fafa')!;
     expect(a2a.url).toBe('https://faf.one/.well-known/agent-card.json');
-    expect(a2a.type).toBe('application/json');
+    expect(a2a.type).toBe('application/a2a-agent-card+json');
     expect(a2a.displayName).toBeUndefined();
     expect(next.entries.find((e) => e.identifier.endsWith(':zeph'))!.url).toContain('zeph');
   });


### PR DESCRIPTION
## Summary
The `faf cards` catalog projector emitted a bare `application/json` type for the A2A Agent Card row it writes into `.well-known/ai-catalog.json`. The ai-catalog spec lists `application/a2a-agent-card+json` as the known type for an A2A Agent Card, and the projector's MCP row already uses `application/mcp-server-card+json` — the A2A row was the odd one out, and a bare `application/json` entry reads second-class next to a natively-typed one.

## Root cause
`catalogEntriesFor()` hard-coded `type: 'application/json'` for the A2A row. It predates the ai-catalog known-type settling on `application/a2a-agent-card+json`; the MCP side was updated, the A2A side wasn't.

## Changes
- `catalogEntriesFor`: emit `application/a2a-agent-card+json` for the A2A row
- `catalogMatchIndex`: match both the canonical type and legacy `application/json` on upsert, so an `ai-catalog.json` written by an older faf-cli is upgraded in place rather than duplicated
- `tests/interop/cards.test.ts`: assert the canonical type — the fixture already used it; the projector was downgrading it on upsert

## Test plan
- [x] `bun test tests/interop/` — 133 pass, 0 fail
- [x] `tsc --noEmit` — no new errors (one pre-existing, unrelated: `src/commands/cards.ts:102`)
- [x] `eslint src/interop/cards.ts` — no new warnings

## Context
Keeps FAF-emitted catalog entries validating against the same rules as native ones — groundwork for FAF pushing `application/vnd.faf+yaml` / `application/vnd.fafa+yaml` as first-class ai-catalog known types.

---
Assisted by Claude · Approved by James Wolfe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aij9ReMwQeQTVSnYUZ4Qdt