### PR TITLE
fix(agents): project.default_branch for git-flow repos + key_files table

### DIFF
--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -92,6 +92,8 @@ export interface FafData {
     goal?: string;
     main_language?: string;
     type?: string;
+    /** Integration branch agents PR into — `dev`/`develop` for git-flow repos. Default `main`. */
+    default_branch?: string;
     [key: string]: unknown;
   };
   /**

--- a/src/interop/agents.ts
+++ b/src/interop/agents.ts
@@ -44,6 +44,9 @@ export function generateAgentsMd(data: FafData): string {
     | undefined;
   const commands = data.commands;
   const keyFiles = data.key_files ?? instant?.key_files;
+  // Integration branch — git-flow repos PR into `dev`/`develop`, not `main`.
+  // Read from project.default_branch; default `main`.
+  const branch = present(data.project?.default_branch) ? String(data.project?.default_branch) : 'main';
 
   const entries = commands ? Object.entries(commands).filter(([, v]) => present(v)) : [];
   // Mutually exclusive so a key like `test:check` classifies ONCE (as a test).
@@ -75,7 +78,7 @@ export function generateAgentsMd(data: FafData): string {
   if (data.project?.main_language) {bits.push(String(data.project.main_language));}
   if (present(data.project?.type)) {bits.push(`type: ${String(data.project?.type)}`);}
   if (present(data.project?.version)) {bits.push(`v${String(data.project?.version)}`);}
-  let orientation = data.project?.goal ? String(data.project.goal) : '';
+  let orientation = data.project?.goal ? String(data.project.goal).trim() : '';
   if (bits.length) {orientation += (orientation ? ' — ' : '') + bits.join(' · ');}
   if (orientation) {
     push(orientation);
@@ -104,11 +107,23 @@ export function generateAgentsMd(data: FafData): string {
     push();
   }
 
-  // §4 Where things live
+  // §4 Where things live — a `Path | Role` table when any entry carries a
+  // " — role" annotation; a plain list when they're all bare paths.
   if (keyFiles && keyFiles.length) {
     push('## Where things live');
     push();
-    for (const f of keyFiles) {push(`- \`${f}\``);}
+    const rows = keyFiles.map((f) => {
+      const s = String(f);
+      const at = s.indexOf(' — ');
+      return at > 0 ? { path: s.slice(0, at), role: s.slice(at + 3) } : { path: s, role: '' };
+    });
+    if (rows.some((r) => r.role)) {
+      push('| Path | Role |');
+      push('|------|------|');
+      for (const r of rows) {push(`| \`${r.path}\` | ${r.role} |`);}
+    } else {
+      for (const r of rows) {push(`- \`${r.path}\``);}
+    }
     push();
   }
 
@@ -146,7 +161,7 @@ export function generateAgentsMd(data: FafData): string {
   push(`- **Always OK:** ${[...new Set(always)].join(' · ')}.`);
   push('- **Ask first:** dependency installs, deletions, migrations, schema changes, publish/release.');
   // Enable-then-restrict: safe path first, then the landmine
-  push('- **Never:** force-push · push straight to `main` (branch and open a PR) · commit secrets.');
+  push(`- **Never:** force-push · push straight to \`${branch}\` (branch and open a PR) · commit secrets.`);
   push();
 
   // §7 Definition of Done
@@ -163,7 +178,7 @@ export function generateAgentsMd(data: FafData): string {
   push('## When stuck');
   push();
   push(
-    'Ask a clarifying question, propose a short plan, or open a draft PR with notes — do not push large speculative changes to `main`.',
+    `Ask a clarifying question, propose a short plan, or open a draft PR with notes — do not push large speculative changes to \`${branch}\`.`,
   );
   push();
 
@@ -187,7 +202,7 @@ export function generateAgentsMd(data: FafData): string {
   } else {
     push('- Conventional Commits preferred (`feat:`, `fix:`, `chore:`, …).');
   }
-  push('- Branch off `main` and open a PR — never commit to `main` directly.');
+  push(`- Branch off \`${branch}\` and open a PR — never commit to \`${branch}\` directly.`);
   push('- If build/test scripts or layout change, refresh this file in the **same PR** (`faf export --agents`).');
   push();
 

--- a/tests/interop/agents.test.ts
+++ b/tests/interop/agents.test.ts
@@ -60,6 +60,23 @@ describe('ENGINE: full data renders every section', () => {
     expect(md).toContain('## Where things live');
     expect(md).toContain('`app/main.py`');
   });
+  test('§4 Where things live: `Path | Role` table when any entry has a " — role" annotation', () => {
+    const m = generateAgentsMd({
+      project: { name: 'x', goal: 'y', main_language: 'Go' },
+      key_files: ['cmd/ — entrypoint', 'internal/', 'go.mod'],
+    } as any);
+    expect(m).toContain('| Path | Role |');
+    expect(m).toContain('| `cmd/` | entrypoint |');
+    expect(m).toContain('| `internal/` |  |');
+  });
+  test('§4 Where things live: plain list when every entry is a bare path', () => {
+    const m = generateAgentsMd({
+      project: { name: 'x', goal: 'y', main_language: 'Go' },
+      key_files: ['cmd/', 'internal/', 'go.mod'],
+    } as any);
+    expect(m).not.toContain('| Path | Role |');
+    expect(m).toContain('- `cmd/`');
+  });
   test('§5 Conventions (real constraints)', () => {
     expect(md).toContain('## Conventions');
     expect(md).toContain('Quality Bar');
@@ -127,6 +144,20 @@ describe('ENGINE: full data renders every section', () => {
     expect(md).toContain('## Commit & PR');
     expect(md).toContain('conventional');
     expect(md).toContain('same PR');
+  });
+  test('§6/§8/§10 branch defaults to `main`', () => {
+    expect(md).toContain('Branch off `main`');
+    expect(md).toContain('push straight to `main`');
+    expect(md).toContain('speculative changes to `main`');
+  });
+  test('§6/§8/§10 branch follows project.default_branch (git-flow)', () => {
+    const m = generateAgentsMd({
+      project: { name: 'x', goal: 'y', main_language: 'Python', default_branch: 'dev' },
+    } as any);
+    expect(m).toContain('Branch off `dev` and open a PR — never commit to `dev` directly.');
+    expect(m).toContain('push straight to `dev` (branch and open a PR)');
+    expect(m).toContain('speculative changes to `dev`.');
+    expect(m).not.toContain('`main`');
   });
   test('Stack renders real stack', () => {
     expect(md).toContain('## Stack');


### PR DESCRIPTION
## What
- `generateAgentsMd` hardcoded "branch off `main`" in 3 places (Guardrails / When-stuck / Commit & PR). Now reads `project.default_branch` (default `main`, unchanged for everyone not using it) — git-flow repos (`dev`/`develop`) get the right branch in their generated AGENTS.md.
- "Where things live" renders a `Path | Role` table when `key_files` entries carry a ` — role` annotation (was wrapping the whole annotated string in backticks); plain list when they're all bare paths. Matches the hand-authored faf-cli AGENTS.md / pubpro table style.
- Trimmed `project.goal` in the orientation line (a multi-line YAML `>` scalar was leaking a trailing newline into the rendered line).

## Why
Surfaced by the first real external AGENTS.md deployment — future-agi/future-agi#2443 / PR #2482 (Django+React+Go, base `dev`). Faf-cli's own repo never hit this because its own branch is `main`.

## Verified
- `bun test` — 1360/1360 pass (5 new)
- `bun run lint` — 0 errors (pre-existing 197 warnings elsewhere, untouched by this diff)
- `bun run build` — clean
- Does not touch the release pipeline (tag-triggered only) — no npm publish implication.

Isolated diff: `src/core/types.ts`, `src/interop/agents.ts`, `tests/interop/agents.test.ts` — 54 insertions, 6 deletions.