### PR TITLE
feat(cli): export --output <path> + check --verbose

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,6 +186,7 @@ program
   .option('--html', 'Author project.html (visual render of project.faf)')
   .option('--card', 'Author MCP Server Card (.well-known/mcp/server-card) with the FAF context-block')
   .option('--all', 'Author all formats')
+  .option('--output <path>', 'Write exported files to this directory instead of the current one')
   .action((options) => exportCommand(options));
 
 program
@@ -219,6 +220,7 @@ program
   .option('--fix', 'Auto-fix issues')
   .option('--doctor', 'Full diagnostic')
   .option('--trust', 'Verify trust chain')
+  .option('--verbose', 'Show slot breakdown')
   .action((file, options) => checkCommand(file, options));
 
 program

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -10,6 +10,7 @@ export interface CheckOptions {
   fix?: boolean;
   doctor?: boolean;
   trust?: boolean;
+  verbose?: boolean;
 }
 
 export function checkCommand(file?: string, options: CheckOptions = {}): void {
@@ -39,7 +40,7 @@ export function checkCommand(file?: string, options: CheckOptions = {}): void {
   console.log(`${fafCyan('valid')} ${fafPath}`);
 
   const result = scoreFafYaml(yaml);
-  displayScore(result, fafPath);
+  displayScore(result, fafPath, options.verbose);
 
   if (options.strict && result.score < 100) {
     console.log(dim('\n  --strict requires 100%'));

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,3 +1,5 @@
+import { mkdirSync } from 'fs';
+import { resolve } from 'path';
 import { findFafFile, readFaf, readFafRaw } from '../interop/faf.js';
 import { writeAgentsMd } from '../interop/agents.js';
 import { enrichFromRepo } from '../detect/enrich.js';
@@ -20,6 +22,8 @@ export interface ExportOptions {
   html?: boolean;
   card?: boolean;
   all?: boolean;
+  /** Write exported files here instead of the current directory. project.faf is still read from cwd. */
+  output?: string;
 }
 
 export function exportCommand(options: ExportOptions = {}): void {
@@ -29,7 +33,8 @@ export function exportCommand(options: ExportOptions = {}): void {
     process.exit(2);
   }
 
-  const dir = process.cwd();
+  const dir = options.output ? resolve(process.cwd(), options.output) : process.cwd();
+  if (options.output) {mkdirSync(dir, { recursive: true });}
   const data = readFaf(fafPath);
   const exportAll =
     options.all ||

--- a/tests/commands/check.test.ts
+++ b/tests/commands/check.test.ts
@@ -1,10 +1,11 @@
-import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { mkdirSync, writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { validateFaf } from '../../src/core/schema.js';
 import { readFaf, readFafRaw } from '../../src/interop/faf.js';
 import * as kernel from '../../src/wasm/kernel.js';
+import { checkCommand } from '../../src/commands/check.js';
 
 describe('BRAKE: check command', () => {
   let testDir: string;
@@ -49,5 +50,26 @@ describe('BRAKE: check command', () => {
     writeFileSync(fafPath, `faf_version: 2.5.0\nproject:\n  name: test\n  goal: Test\n  main_language: TypeScript\n`);
     const yaml = readFafRaw(fafPath);
     expect(kernel.validate(yaml)).toBe(true);
+  });
+
+  test('--verbose prints the per-slot breakdown; default run does not', () => {
+    const fafPath = join(testDir, 'project.faf');
+    writeFileSync(fafPath, `faf_version: 2.5.0\nproject:\n  name: verbose-test\n  goal: Test\n  main_language: TypeScript\n`);
+
+    const logSpy = spyOn(console, 'log');
+
+    logSpy.mockClear();
+    checkCommand(fafPath, {});
+    const quiet = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+
+    logSpy.mockClear();
+    checkCommand(fafPath, { verbose: true });
+    const verbose = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+
+    logSpy.mockRestore();
+
+    expect(verbose).toContain('project.name');
+    expect(quiet).not.toContain('project.name');
+    expect(verbose.length).toBeGreaterThan(quiet.length);
   });
 });

--- a/tests/commands/export.test.ts
+++ b/tests/commands/export.test.ts
@@ -115,6 +115,27 @@ describe('TYRE: export command', () => {
     expect(existsSync(join(testDir, 'GEMINI.md'))).toBe(false);
   });
 
+  test('--output writes to another directory; project.faf stays read from cwd', () => {
+    writeFileSync(join(testDir, 'project.faf'), `faf_version: 2.5.0\nproject:\n  name: output-test\n  goal: Test\n  main_language: TypeScript\n`);
+
+    const { exportCommand } = require('../../src/commands/export.js');
+    exportCommand({ agents: true, output: 'dist/context' });
+
+    const out = join(testDir, 'dist', 'context', 'AGENTS.md');
+    expect(existsSync(out)).toBe(true);
+    expect(readFileSync(out, 'utf-8')).toContain('output-test');
+    expect(existsSync(join(testDir, 'AGENTS.md'))).toBe(false);
+  });
+
+  test('--output creates a nested directory that does not exist yet', () => {
+    writeFileSync(join(testDir, 'project.faf'), `faf_version: 2.5.0\nproject:\n  name: output-mkdir-test\n  goal: Test\n  main_language: TypeScript\n`);
+
+    const { exportCommand } = require('../../src/commands/export.js');
+    exportCommand({ all: true, output: 'a/b/c' });
+
+    expect(existsSync(join(testDir, 'a', 'b', 'c', 'AGENTS.md'))).toBe(true);
+  });
+
   test('copilot-instructions.md is idempotent (no duplicate faf block on re-run)', () => {
     writeFileSync(join(testDir, 'project.faf'), `faf_version: 2.5.0\nproject:\n  name: idem-test\n  goal: Test\n  main_language: TypeScript\n`);
 


### PR DESCRIPTION
## What
- `faf export` gains **`--output <path>`** — writes exported files (AGENTS.md, .cursorrules, GEMINI.md, etc.) to that directory instead of always the current one. Created recursively if it doesn't exist. `project.faf` is still discovered/read from cwd — only the write target moves.
- `faf check` gains **`--verbose`** — `displayScore()` already supported a verbose per-slot breakdown (`faf score --verbose` had it wired); `faf check` was just missing the flag.

## Why
Both are real friction hit today authoring future-agi/future-agi#2443's `project.faf`/`AGENTS.md`: had to `cd` into the target clone and copy files by hand instead of exporting straight there, and `faf check --verbose` errored with `unknown option` when I wanted the slot breakdown without a separate `faf score` call.

## Verified
- `bun test` — 1363/1363 pass (3 new)
- `bun run lint` — 0 errors (same 197 pre-existing warnings, untouched)
- `bun run build` — clean
- Manual: `export --agents --output somewhere/nested` creates the dir and writes only there; `check --verbose` prints the slot breakdown, plain `check` doesn't.

Isolated diff: `src/cli.ts`, `src/commands/export.ts`, `src/commands/check.ts`, 2 test files — 54 insertions, 3 deletions.