### PR TITLE
feat: repo fact-extraction + polyglot honesty (7.10.0 — The Full-Facts Edition)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- faf: faf-cli | TypeScript | cli | CLI for the .faf format — IANA-registered AI context that versions with your code -->
-<!-- faf: doc=changelog | latest=v7.9.0 | canonical=project.faf | family=FAF -->
+<!-- faf: doc=changelog | latest=v7.10.0 | canonical=project.faf | family=FAF -->
 
 # Changelog
 
@@ -9,6 +9,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [7.10.0] - 2026-09-02 — The Full-Facts Edition
+
+**`faf git` reads the tree it clones — docker-compose services, Makefile targets, sibling app dirs — instead of leaning on the README. A polyglot repo stops reporting `library` / `JavaScript`.**
+
+### Added
+- **Polyglot detection** — a repo whose real stack lives in sibling dirs (a frontend AND a backend, ≥2 languages, no npm workspace) now classifies as **`fullstack`** with an aggregated `main_language` (`"Python (Django · backend); Go (backend); TypeScript (React · frontend)"`) and a `# found: polyglot: dir/ (Lang), …` rationale — instead of falling to `type: library` / `main_language: JavaScript`. No new app-type; monorepo/enterprise slot work is out of scope.
+- **`docker-compose` fact-extraction** — service images map onto stack slots: `postgres`/`clickhouse`/`mysql` → `stack.database`, `redis` → `cache`, `minio` → `storage`, `elasticsearch`/`qdrant`/`weaviate` → `search`, `kafka`/`rabbitmq`/`temporal` → `stack.runtime`. Found at the repo root and one directory deep.
+- **Build-file commands** — `Makefile` / `justfile` / `Taskfile` targets → `commands.{test,build,lint}`, nested-dir aware (`cd futureagi && make test`). `check-all` wins the lint slot.
+- **`.env.example`** → `security.secrets` + `security.example`.
+
+### Changed
+- **File-facts beat prose.** The new interrogators' `stack` / `commands` / `security` output takes precedence over README guesses and presence-only detectors.
+- A polyglot repo's tooling-shell root `package.json` no longer seeds `project.goal` or `human_context.what`.
+
+### Fixed
+- README extraction strips `<!-- … -->` comment blocks (asset notes, TODO markers) before reading — their text could seed a slot.
+- Link-list section bodies (a roadmap row of markdown links) are rejected as prose — no longer land in `human_context.when`.
+
+### Notes / non-claims
+- **Do NOT claim:** monorepo/enterprise support (that's a separate tool) · full YAML parsing of compose (image-name regex) · Windows (CI matrix is ubuntu + macos only).
+- **Kill line:** faf git reads the repo, not the README.
+
+### Verification (claim inventory)
+| Claim | Evidence command |
+|-------|------------------|
+| polyglot repo → `fullstack` + aggregated language | `bun test tests/detect/new-types.test.ts` |
+| compose services → stack slots | `bun test tests/interrogate/compose.test.ts` |
+| Makefile targets → commands (nested-aware) | `bun test tests/interrogate/build-files.test.ts` |
+| README noise (comments / link rows) rejected | `bun test tests/wjttc/relentless.test.ts` |
 
 ## [7.9.0] - 2026-09-01 — The Git-Flow Edition
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 <!-- faf:start -->
-<!-- faf: faf-cli | TypeScript | cli | CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memory. TypeScript, Bun-native since v6. package faf-cli v7.9.0 The Git-Flow Edition. -->
+<!-- faf: faf-cli | TypeScript | cli | CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memory. TypeScript, Bun-native since v6. package faf-cli v7.10.0 The Full-Facts Edition. -->
 <!-- faf: claim=project.faf | family=FAF -->
 
 # CLAUDE.md — faf-cli
 
 ## What This Is
 
-CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memory. TypeScript, Bun-native since v6. package faf-cli v7.9.0 The Git-Flow Edition.
+CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memory. TypeScript, Bun-native since v6. package faf-cli v7.10.0 The Full-Facts Edition.
 
 ## Stack
 
@@ -18,10 +18,10 @@ CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memo
 - **What:** Persistent AI Context Standard — project DNA for AI. IANA-registered. Anthropic-merged.
 - **Why:** Eliminates 91% context re-discovery tax — define once, AI remembers forever
 - **Where:** npm registry, Homebrew, GitHub
-- **When:** Production since September 2025; Bun-native since v6; current package 7.9.0
+- **When:** Production since September 2025; Bun-native since v6; current package 7.10.0
 - **How:** bunx faf-cli auto, then project.faf versions with your code — faf show renders it human-visible
 
 ---
 
-*STATUS: BI-SYNC ACTIVE — 2026-09-01T16:24:56.907Z*
+*STATUS: BI-SYNC ACTIVE — 2026-09-01T23:37:30.573Z*
 <!-- faf:end -->

--- a/README.md
+++ b/README.md
@@ -131,34 +131,31 @@ faf memory etch "a durable fact" --id my-fact
 faf memory show
 ```
 
-### What's New in v7.9.0 — The Git-Flow Edition
+### What's New in v7.10.0 — The Full-Facts Edition
 
-**`faf export` respects your repo's branch model — `project.default_branch` drives the `AGENTS.md` PR base instead of a hardcoded `main`.**
-
-Set it once in `project.faf`; git-flow repos that PR into `dev` / `develop` get the right base everywhere `faf export` writes it. Default stays `main` when the field is absent.
-
-```yaml
-# project.faf
-project:
-  default_branch: dev
-```
+**`faf git` reads the tree it clones — docker-compose services, Makefile targets, sibling app dirs — instead of leaning on the README.**
 
 ```bash
-faf export --agents --output docs/context   # write anywhere, not just cwd
-faf check --verbose                          # per-slot breakdown with validation
+faf git future-agi/future-agi
 ```
 
-- **`key_files` annotations** — write `src/ — entrypoint` and it renders as a `Path | Role` table in "Where things live".
-- Surfaced by the first external `AGENTS.md` deployment (future-agi, base `dev`).
+A polyglot repo (Django + React + Go, no npm workspace) used to report `type: library` / `main_language: JavaScript` / no stack. Now:
 
-**Recent sprint** — 7 ships
+- **`type: fullstack`** with `main_language: "Python (Django · backend); Go (backend); TypeScript (React · frontend)"` and a `# found: polyglot: …` rationale
+- **`stack.database: PostgreSQL · ClickHouse`** — read from `docker-compose.yml` service images (`redis` → cache, `minio` → storage, `kafka`/`temporal` → runtime)
+- **`commands.test: cd futureagi && make test`** — read from the nested `Makefile`
+- **`security`** — from `.env.example`
 
+File-facts beat README guesses. README extraction now strips `<!-- -->` comment blocks and rejects link-list rows.
+
+**Recent sprint**
+
+- 🌱 [7.9.0](https://github.com/Wolfe-Jam/faf-cli/releases/tag/v7.9.0) The Git-Flow Edition
 - 🎬 [7.8.0](https://github.com/Wolfe-Jam/faf-cli/releases/tag/v7.8.0) The Projector Edition
 - 🐦 [7.7.0](https://github.com/Wolfe-Jam/faf-cli/releases/tag/v7.7.0) The Swift Edition
 - 💎 [7.6.0](https://github.com/Wolfe-Jam/faf-cli/releases/tag/v7.6.0) The Ruby Edition
 - ☕ [7.5.1](https://github.com/Wolfe-Jam/faf-cli/releases/tag/v7.5.1) The JVM Edition
 - 💠 [7.4.0](https://github.com/Wolfe-Jam/faf-cli/releases/tag/v7.4.0) The C# Edition
-- 🐹 [7.3.0](https://github.com/Wolfe-Jam/faf-cli/releases/tag/v7.3.0) The Go Edition
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faf-cli",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faf-cli",
-      "version": "7.9.0",
+      "version": "7.10.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faf-cli",
-  "version": "7.9.0",
+  "version": "7.10.0",
   "description": "Persistent AI context + memory — .faf and .fafm, IANA-registered. Anthropic-merged.",
   "type": "module",
   "icon": "https://faf.one/orange-smiley.svg",

--- a/project.faf
+++ b/project.faf
@@ -1,8 +1,8 @@
 faf_version: "3.0"
 project:
   name: faf-cli
-  version: "7.9.0"
-  goal: "CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memory. TypeScript, Bun-native since v6. package faf-cli v7.9.0 The Git-Flow Edition."
+  version: "7.10.0"
+  goal: "CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memory. TypeScript, Bun-native since v6. package faf-cli v7.10.0 The Full-Facts Edition."
   main_language: TypeScript
   type: cli  # found: package.json bin
 # Commands + key_files feed `faf export --agents` (hand values win over detection).
@@ -58,7 +58,7 @@ human_context:
   what: Persistent AI Context Standard — project DNA for AI. IANA-registered. Anthropic-merged.
   why: Eliminates 91% context re-discovery tax — define once, AI remembers forever
   where: npm registry, Homebrew, GitHub
-  when: Production since September 2025; Bun-native since v6; current package 7.9.0
+  when: Production since September 2025; Bun-native since v6; current package 7.10.0
   how: bunx faf-cli auto, then project.faf versions with your code — faf show renders it human-visible
 monorepo:
   packages_count: slotignored

--- a/src/detect/assemble.ts
+++ b/src/detect/assemble.ts
@@ -16,12 +16,27 @@ import { APP_TYPE_CATEGORIES, SLOTS, isPlaceholder } from '../core/slots.js';
 /** Build a fresh .faf for `dir` using the full slot-filling pipeline. */
 export function assembleFreshFaf(dir: string): Record<string, unknown> {
   const detected = detectStack(dir) as Record<string, unknown>;
-  const interrogated = interrogateRepo(dir) as Record<string, unknown>;
+  const facts = interrogateRepo(dir);
 
-  const seeded = fillEmpties(detected, interrogated);
+  // File-facts (stack / commands / security — docker-compose, Makefile, .env)
+  // are ground truth: they WIN over detectStack's root-only presence guesses.
+  const factLayer: Record<string, unknown> = {};
+  if (facts.stack) {factLayer.stack = facts.stack;}
+  if (facts.commands) {factLayer.commands = facts.commands;}
+  if (facts.security) {factLayer.security = facts.security;}
+  // Prose (goal / 6Ws — README, Cargo.toml) fills empties only.
+  const proseLayer: Record<string, unknown> = {};
+  if (facts.project) {proseLayer.project = facts.project;}
+  if (facts.human_context) {proseLayer.human_context = facts.human_context;}
+
+  const seeded = fillEmpties(fillEmpties(factLayer, detected), proseLayer);
   applySlotIgnore(seeded);
+  // Polyglot repos: the root package.json is a tooling shell — don't let its
+  // description/scripts seed the product's 6Ws.
+  const found = (detected._meta as { found?: string[] } | undefined)?.found ?? [];
+  const toolingRoot = found.some(f => f.startsWith('polyglot:'));
   const withFormats = fillEmpties(seeded, turboCatSlots(dir) as Record<string, unknown>);
-  return fillEmpties(withFormats, { human_context: relentlessContext(dir) } as Record<string, unknown>);
+  return fillEmpties(withFormats, { human_context: relentlessContext(dir, { toolingRoot }) } as Record<string, unknown>);
 }
 
 /** Mark slots outside the app-type's active categories as `slotignored`. */

--- a/src/detect/relentless.ts
+++ b/src/detect/relentless.ts
@@ -63,8 +63,13 @@ const sv = (value: string, source: string, confidence: number): SourcedValue => 
  * confidence}. This is the auditable form: the seeded/confirm UI can show the
  * human WHERE a value was relocated from before they accept it.
  */
-export function relentlessContextDetailed(dir: string): SeededContextDetailed {
-  const pkg = readPkg(dir);
+/** `toolingRoot`: the repo root's package.json is a tooling shell (polyglot repo
+ *  — real code is in sibling dirs), so its description/repo/scripts describe the
+ *  tooling, not the product. Skip package.json-sourced context; README only. */
+export interface RelentlessOpts { toolingRoot?: boolean }
+
+export function relentlessContextDetailed(dir: string, opts: RelentlessOpts = {}): SeededContextDetailed {
+  const pkg = opts.toolingRoot ? null : readPkg(dir);
   const readme = cleanReadme(dir);
   const out: SeededContextDetailed = {};
   const set = (k: keyof SeededContextDetailed, v: SourcedValue | null): void => {
@@ -87,8 +92,8 @@ export function relentlessContextDetailed(dir: string): SeededContextDetailed {
  * the pre-provenance version). Existing consumers (claude-faf-mcp's faf_auto)
  * keep working unchanged; opt into provenance via the Detailed form.
  */
-export function relentlessContext(dir: string): SeededContext {
-  const detailed = relentlessContextDetailed(dir);
+export function relentlessContext(dir: string, opts: RelentlessOpts = {}): SeededContext {
+  const detailed = relentlessContextDetailed(dir, opts);
   const seed: SeededContext = {};
   (Object.keys(detailed) as (keyof SeededContextDetailed)[]).forEach((k) => {
     const sourced = detailed[k];
@@ -118,6 +123,7 @@ function cleanReadme(dir: string): string {
     return '';
   }
   return txt
+    .replace(/<!--[\s\S]*?-->/g, '') // HTML comment blocks (asset notes, TODOs — not prose)
     .split('\n')
     .filter((l) => !/^\s*\[!\[/.test(l) && !/^\s*!\[/.test(l)) // badge lines
     .join('\n')
@@ -130,12 +136,21 @@ function clean(text: string): string {
   return text.replace(/\s+/g, ' ').replace(/[#*`>]/g, '').trim().slice(0, 280);
 }
 
+/** Share of a string's characters that sit inside markdown/inline links. */
+function linkDensity(s: string): number {
+  if (!s) {return 0;}
+  const linked = (s.match(/\[[^\]]*\]\([^)]*\)/g) ?? []).join('').length;
+  return linked / s.length;
+}
+
 /** First `## Section` body matching any of the pipe-listed names (min 20 chars).
- *  Returns the cleaned body AND the matched heading (for provenance labels). */
+ *  Returns the cleaned body AND the matched heading (for provenance labels).
+ *  Rejects link-list bodies (nav / roadmap-link rows are not prose). */
 function section(readme: string, names: string): { body: string; heading: string } | null {
   const re = new RegExp(`##?\\s+(${names})\\s*\\n+([\\s\\S]+?)(?:\\n\\n|\\n##?|$)`, 'i');
   const m = readme.match(re);
-  return m && m[2] && m[2].trim().length > 20 ? { body: clean(m[2]), heading: m[1].trim() } : null;
+  if (!m || !m[2] || m[2].trim().length <= 20 || linkDensity(m[2]) > 0.4) {return null;}
+  return { body: clean(m[2]), heading: m[1].trim() };
 }
 
 /** First capturing-group match across patterns whose capture meets minLen. */

--- a/src/detect/scanner.ts
+++ b/src/detect/scanner.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, type Dirent } from 'fs';
 import { join } from 'path';
 import type { DetectedFramework, Signal } from '../core/types.js';
 import { FRAMEWORKS } from './frameworks.js';
@@ -264,6 +264,124 @@ function detectMonorepoRootSignal(dir: string, pkg: PackageJson | null): string 
   const hasWorkspaces = !!pkg.workspaces || existsSync(join(dir, 'pnpm-workspace.yaml'));
   if (!hasWorkspaces) {return null;}
   return 'private workspace + multi-package';
+}
+
+/** Top-level dirs that never hold an app component. */
+const SUBDIR_IGNORE = new Set([
+  'node_modules', 'dist', 'build', 'out', 'vendor', 'target', 'coverage',
+  'docs', 'doc', 'e2e', 'tests', 'test', '__tests__', 'scripts', 'deploy',
+  'bin', 'public', 'examples', 'example', 'fixtures', 'assets', 'static',
+  'migrations', 'config', 'contracts', 'proto', 'protos',
+]);
+
+const BACKEND_LANG_RE = /^(Python|Go|Rust|Ruby|Java|Kotlin)$/;
+
+/** One app component discovered directly under the repo root. */
+export interface SubdirStack {
+  /** basename */
+  name: string;
+  /** detectLanguage() of the subdir */
+  language: string;
+  /** highest-confidence real-stack framework in the subdir (never Docker/CI/etc.) */
+  topFramework: string | null;
+  frontend: boolean;
+  backend: boolean;
+  /** a real-stack framework (not infra) was detected — ranks it as the "primary" */
+  hasFramework: boolean;
+  /** a "this dir IS the app" marker (manage.py / config.ru / bin/rails) */
+  appRoot: boolean;
+}
+
+/** Framework categories that describe the app's own stack (not infra/tooling). */
+const STACK_FW_CATEGORIES = new Set(['frontend', 'backend', 'database', 'css', 'ui', 'state']);
+
+/** A directory carries a real language manifest (not just tooling/config). */
+function hasLanguageManifest(d: string): boolean {
+  if (
+    existsSync(join(d, 'pyproject.toml')) || existsSync(join(d, 'manage.py')) ||
+    existsSync(join(d, 'setup.py')) || fileExists(d, 'requirements*.txt')
+  ) {return true;}
+  if (existsSync(join(d, 'go.mod'))) {return true;}
+  if (existsSync(join(d, 'Cargo.toml'))) {return true;}
+  if (existsSync(join(d, 'Gemfile'))) {return true;}
+  if (existsSync(join(d, 'pom.xml')) || fileExists(d, 'build.gradle*')) {return true;}
+  if (listRootCsprojs(d).length > 0) {return true;}
+  const pkg = readPackageJson(d);
+  if (pkg && Object.keys(pkg.dependencies ?? {}).length > 0) {return true;}
+  return false;
+}
+
+/** Shallow (depth-1) scan for per-subdirectory app stacks. Feeds the polyglot
+ *  classifier + `main_language` aggregation. A dir counts only when it carries a
+ *  real language manifest. This is NOT monorepo tooling — it only exists to stop
+ *  a repo whose real stack lives in subdirs from falling to the `library` lie. */
+export function detectSubdirStacks(dir: string): SubdirStack[] {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: SubdirStack[] = [];
+  for (const e of entries) {
+    if (!e.isDirectory() || e.name.startsWith('.') || SUBDIR_IGNORE.has(e.name)) {continue;}
+    const sub = join(dir, e.name);
+    if (!hasLanguageManifest(sub)) {continue;}
+    const language = detectLanguage(sub);
+    if (language === 'Unknown') {continue;}
+    const fws = detectFrameworks(sub).filter(f => STACK_FW_CATEGORIES.has(f.category));
+    const fe = fws.find(f => f.category === 'frontend');
+    const be = fws.find(f => f.category === 'backend');
+    const top = fe ?? be ?? fws[0] ?? null;
+    out.push({
+      name: e.name,
+      language,
+      topFramework: top?.name ?? null,
+      frontend: !!fe,
+      backend: !!be || BACKEND_LANG_RE.test(language),
+      hasFramework: !!top,
+      appRoot:
+        existsSync(join(sub, 'manage.py')) ||
+        existsSync(join(sub, 'config.ru')) ||
+        existsSync(join(sub, 'bin/rails')) ||
+        existsSync(join(sub, 'artisan')),
+    });
+  }
+  return out;
+}
+
+/** Polyglot signal — ≥2 sibling app dirs, ≥2 distinct languages, a frontend AND
+ *  a backend among them. Returns the `# found:` evidence string, or null. */
+export function detectPolyglotSignal(dir: string, pkg: PackageJson | null): string | null {
+  if (pkg?.workspaces || existsSync(join(dir, 'pnpm-workspace.yaml'))) {return null;}
+  const subs = detectSubdirStacks(dir);
+  const langs = new Set(subs.map(s => s.language));
+  if (subs.length < 2 || langs.size < 2) {return null;}
+  if (!subs.some(s => s.frontend) || !subs.some(s => s.backend)) {return null;}
+  return `polyglot: ${subs.map(s => `${s.name}/ (${s.language})`).join(', ')}`;
+}
+
+/** Aggregate the polyglot `main_language` string — primary first (a framework-
+ *  bearing backend dir wins), deduped by language, roles annotated.
+ *  e.g. "Python (Django · backend); JavaScript (React · frontend); Go (service)" */
+export function detectPolyglotLanguage(dir: string): string | null {
+  const subs = detectSubdirStacks(dir);
+  if (subs.length < 2) {return null;}
+  const score = (s: SubdirStack): number =>
+    (s.appRoot ? 2 : 0) +
+    (BACKEND_LANG_RE.test(s.language) ? 2 : 0) +
+    (s.hasFramework ? 1 : 0) +
+    (s.frontend ? 0.5 : 0);
+  const ranked = [...subs].sort((a, b) => score(b) - score(a));
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const s of ranked) {
+    if (seen.has(s.language)) {continue;}
+    seen.add(s.language);
+    const role = s.frontend ? 'frontend' : s.backend ? 'backend' : 'service';
+    parts.push(s.topFramework ? `${s.language} (${s.topFramework} · ${role})` : `${s.language} (${role})`);
+  }
+  return parts.join('; ');
 }
 
 /** Read and parse package.json from a directory */
@@ -625,6 +743,16 @@ export function detectProjectTypeWithRationale(dir: string): ProjectTypeDetectio
   if (htmlSignal) {
     found.push(htmlSignal);
     return { type: 'html', found };
+  }
+
+  // ─── 19b. polyglot — real stack lives in sibling app dirs (FE + BE, ≥2
+  //          languages). NOT a monorepo tool (that's xai-faf-rust) — this only
+  //          rescues the repo from the `library` fallback lie below. Uses the
+  //          existing `fullstack` type (21 slots); no new app_type. ──────────
+  const polyglotSignal = detectPolyglotSignal(dir, pkg);
+  if (polyglotSignal) {
+    found.push(polyglotSignal);
+    return { type: 'fullstack', found };
   }
 
   // ─── 20. library — fallback (has main/exports but no bin) ──────────────

--- a/src/detect/stack.ts
+++ b/src/detect/stack.ts
@@ -4,6 +4,8 @@ import { FAF_VERSION } from '../core/version.js';
 import {
   detectFrameworks,
   detectLanguage,
+  detectPolyglotLanguage,
+  detectSubdirStacks,
   detectProjectTypeWithRationale,
   detectRuntime,
   detectPackageManager,
@@ -21,9 +23,12 @@ import {
 export function detectStack(dir: string): FafData {
   const pkg = readPackageJson(dir);
   const frameworks = detectFrameworks(dir);
-  const language = detectLanguage(dir);
   const detection = detectProjectTypeWithRationale(dir);
   const projectType = detection.type;
+  // Polyglot repos (real stack in sibling dirs) get an aggregated language
+  // string instead of the misleading root-only detectLanguage() fallback.
+  const isPolyglot = detection.found.some(f => f.startsWith('polyglot:'));
+  const language = (isPolyglot && detectPolyglotLanguage(dir)) || detectLanguage(dir);
   const runtime = detectRuntime(dir);
   const pkgManager = detectPackageManager(dir);
   const cicd = detectCicd(dir);
@@ -129,7 +134,9 @@ export function detectStack(dir: string): FafData {
   // Build project section
   const project: Record<string, string> = {
     name: pkg?.name ?? dir.split('/').pop() ?? 'project',
-    goal: pkg?.description ?? '',
+    // A polyglot repo's root package.json describes the tooling shell, not the
+    // product — leave goal for the README interrogator / the human to fill.
+    goal: isPolyglot ? '' : (pkg?.description ?? ''),
     main_language: language,
     type: projectType,
   };
@@ -143,7 +150,17 @@ export function detectStack(dir: string): FafData {
   // tech_stack/key_files/commands auto-populate from observable signals;
   // architecture/context stay empty (user fill — architecture overlaps with
   // human_context.how, context is free-form additional signal).
-  const techStack = detectTechStack(dir, pkg, frameworks, language);
+  // Feed detectTechStack the ROOT language (a single token), never the polyglot
+  // summary string — that belongs only in project.main_language.
+  const techStack = detectTechStack(dir, pkg, frameworks, isPolyglot ? detectLanguage(dir) : language);
+  if (isPolyglot) {
+    // Add each sibling component's language + top framework (deduped, order-stable).
+    for (const s of detectSubdirStacks(dir)) {
+      for (const t of [s.language, s.topFramework]) {
+        if (t && !techStack.includes(t)) {techStack.push(t);}
+      }
+    }
+  }
   const keyFiles = detectKeyFiles(dir);
   const commands = detectCommands(dir, pkg);
 
@@ -153,7 +170,9 @@ export function detectStack(dir: string): FafData {
     stack,
     human_context: {
       who: '',
-      what: pkg?.description ?? '',
+      // A polyglot root's package.json describes the tooling shell, not the
+      // product — leave `what` for the README interrogator / the human.
+      what: isPolyglot ? '' : (pkg?.description ?? ''),
       why: '',
       where: '',
       when: '',

--- a/src/interrogate/build-files.ts
+++ b/src/interrogate/build-files.ts
@@ -1,0 +1,110 @@
+/**
+ * Makefile / justfile / Taskfile interrogation — the real project commands.
+ *
+ * `detectCommands` in scanner.ts only reads root package.json scripts + language
+ * defaults. Many repos (esp. polyglot ones) drive test/build/lint through a
+ * Makefile — `make test`, `make check-all`. Read the target names and map the
+ * obvious ones. Facts from files, not README prose.
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import type { ExtractedContext } from './types.js';
+
+const IGNORE_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', 'vendor', 'target', 'e2e', 'docs', 'scripts',
+]);
+
+interface BuildFile {
+  file: string;
+  runner: string;
+  /** extract target names from the file body */
+  targets: (body: string) => string[];
+}
+
+const BUILD_FILES: BuildFile[] = [
+  {
+    file: 'Makefile',
+    runner: 'make',
+    // `target:` at column 0, not `.PHONY` / pattern rules / variables
+    targets: (b) => [...b.matchAll(/^([a-zA-Z][\w-]*)\s*:(?!=)/gm)].map(m => m[1]),
+  },
+  {
+    file: 'justfile',
+    runner: 'just',
+    targets: (b) => [...b.matchAll(/^([a-zA-Z][\w-]*)\s*(?:\([^)]*\))?\s*:/gm)].map(m => m[1]),
+  },
+  {
+    file: 'Taskfile.yml',
+    runner: 'task',
+    targets: (b) => {
+      const i = b.indexOf('tasks:');
+      if (i === -1) {return [];}
+      return [...b.slice(i).matchAll(/^\s{2}([a-zA-Z][\w-]*):/gm)].map(m => m[1]);
+    },
+  },
+];
+
+/** Pick the best target for a command slot, preferring the more complete one. */
+function pick(targets: string[], patterns: RegExp[]): string | null {
+  for (const p of patterns) {
+    const hit = targets.find(t => p.test(t));
+    if (hit) {return hit;}
+  }
+  return null;
+}
+
+/** Root, then each depth-1 subdir (so a nested `backend/Makefile` is found). */
+function buildFileDirs(dir: string): string[] {
+  const dirs = [dir];
+  try {
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      if (e.isDirectory() && !e.name.startsWith('.') && !IGNORE_DIRS.has(e.name)) {
+        dirs.push(join(dir, e.name));
+      }
+    }
+  } catch { /* unreadable — root only */ }
+  return dirs;
+}
+
+/** Does `d` look like the primary backend/app dir? (raises its command priority) */
+function looksPrimary(d: string): number {
+  let s = 0;
+  if (existsSync(join(d, 'manage.py')) || existsSync(join(d, 'pyproject.toml')) || existsSync(join(d, 'Gemfile'))) {s += 3;}
+  if (/(?:^|\/)(backend|api|server|core|app)$/.test(d)) {s += 2;}
+  return s;
+}
+
+export function interrogateBuildFiles(dir: string): ExtractedContext {
+  const candidates: Array<{ score: number; commands: Record<string, string> }> = [];
+
+  for (const scanDir of buildFileDirs(dir)) {
+    const isRoot = scanDir === dir;
+    const prefix = isRoot ? '' : `cd ${scanDir.slice(dir.length + 1)} && `;
+    for (const bf of BUILD_FILES) {
+      const path = join(scanDir, bf.file);
+      if (!existsSync(path)) {continue;}
+      let body: string;
+      try { body = readFileSync(path, 'utf-8'); } catch { continue; }
+      const targets = bf.targets(body);
+      if (targets.length === 0) {continue;}
+
+      const commands: Record<string, string> = {};
+      const test = pick(targets, [/^test$/i, /^tests$/i, /test-all/i, /^test-unit/i, /^test/i]);
+      const build = pick(targets, [/^build$/i, /^compile$/i, /^build/i]);
+      const lint = pick(targets, [/^check-all$/i, /^check$/i, /^lint$/i, /^lint/i, /^fmt$/i, /^format$/i]);
+      if (test) {commands.test = `${prefix}${bf.runner} ${test}`;}
+      if (build) {commands.build = `${prefix}${bf.runner} ${build}`;}
+      if (lint) {commands.lint = `${prefix}${bf.runner} ${lint}`;}
+      if (Object.keys(commands).length === 0) {continue;}
+
+      candidates.push({
+        score: Object.keys(commands).length + (isRoot ? 10 : looksPrimary(scanDir)),
+        commands,
+      });
+    }
+  }
+
+  const best = candidates.sort((a, b) => b.score - a.score)[0];
+  return best ? { commands: best.commands } : {};
+}

--- a/src/interrogate/compose.ts
+++ b/src/interrogate/compose.ts
@@ -1,0 +1,99 @@
+/**
+ * docker-compose interrogation — the services a repo runs ARE its stack.
+ *
+ * A polyglot / platform repo declares Postgres, Redis, ClickHouse, MinIO, Kafka…
+ * in compose and nowhere the root-only detectors look. We read the `image:` lines
+ * (naive regex — same style as cargo.ts's TOML reader) and map well-known infra
+ * images onto stack slots. Facts, not prose — so these win over README guesses.
+ */
+
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import type { ExtractedContext } from './types.js';
+
+/** image name (before ':' tag, after last '/') → { slot, label }. */
+const IMAGE_MAP: Array<{ re: RegExp; slot: 'database' | 'cache' | 'search' | 'storage' | 'runtime'; label: string }> = [
+  { re: /^postgres|postgis|pgvector/, slot: 'database', label: 'PostgreSQL' },
+  { re: /^mysql/, slot: 'database', label: 'MySQL' },
+  { re: /^mariadb/, slot: 'database', label: 'MariaDB' },
+  { re: /^mongo/, slot: 'database', label: 'MongoDB' },
+  { re: /clickhouse/, slot: 'database', label: 'ClickHouse' },
+  { re: /^cockroach/, slot: 'database', label: 'CockroachDB' },
+  { re: /^redis|^valkey/, slot: 'cache', label: 'Redis' },
+  { re: /^memcached/, slot: 'cache', label: 'Memcached' },
+  { re: /elasticsearch/, slot: 'search', label: 'Elasticsearch' },
+  { re: /opensearch/, slot: 'search', label: 'OpenSearch' },
+  { re: /meilisearch/, slot: 'search', label: 'Meilisearch' },
+  { re: /typesense/, slot: 'search', label: 'Typesense' },
+  { re: /qdrant/, slot: 'search', label: 'Qdrant (vector)' },
+  { re: /weaviate/, slot: 'search', label: 'Weaviate (vector)' },
+  { re: /^minio/, slot: 'storage', label: 'MinIO (S3-compatible)' },
+  { re: /localstack/, slot: 'storage', label: 'LocalStack (AWS)' },
+  { re: /rabbitmq/, slot: 'runtime', label: 'RabbitMQ' },
+  { re: /kafka/, slot: 'runtime', label: 'Kafka' },
+  { re: /nats/, slot: 'runtime', label: 'NATS' },
+  { re: /temporalio\/|temporal-server|temporal:/, slot: 'runtime', label: 'Temporal' },
+];
+
+const IGNORE_DIRS = new Set([
+  'node_modules', '.git', 'dist', 'build', 'vendor', 'target', 'e2e', 'tests', 'test',
+]);
+
+/** Every compose file at root + one directory deep. */
+function findComposeFiles(dir: string): string[] {
+  const out: string[] = [];
+  const scan = (d: string, depth: number): void => {
+    let entries: import('fs').Dirent[];
+    try { entries = readdirSync(d, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      if (e.isFile() && /^(docker-)?compose.*\.ya?ml$/i.test(e.name)) {out.push(join(d, e.name));}
+      else if (e.isDirectory() && depth > 0 && !e.name.startsWith('.') && !IGNORE_DIRS.has(e.name)) {
+        scan(join(d, e.name), depth - 1);
+      }
+    }
+  };
+  scan(dir, 1);
+  return out;
+}
+
+/** Join distinct labels for a slot: "PostgreSQL · ClickHouse". */
+function joinSlot(labels: Set<string>): string {
+  return [...labels].join(' · ');
+}
+
+/** Read every compose file and map service images onto stack slots. */
+export function interrogateCompose(dir: string): ExtractedContext {
+  const files = findComposeFiles(dir);
+  if (files.length === 0) {return {};}
+
+  const found: Record<string, Set<string>> = {
+    database: new Set(), cache: new Set(), search: new Set(), storage: new Set(), runtime: new Set(),
+  };
+
+  for (const file of files) {
+    let body: string;
+    try { body = readFileSync(file, 'utf-8'); } catch { continue; }
+    for (const m of body.matchAll(/^\s*image:\s*["']?([^\s"'#]+)/gm)) {
+      const ref = m[1].toLowerCase();
+      // strip registry host + tag: ghcr.io/foo/redis:7-alpine → redis
+      const name = ref.replace(/:[^/]*$/, '').split('/').pop() ?? ref;
+      const hostAndName = ref.replace(/:[^/]*$/, ''); // keep owner for temporalio/ etc.
+      for (const { re, slot, label } of IMAGE_MAP) {
+        if (re.test(name) || re.test(hostAndName)) {found[slot].add(label);}
+      }
+    }
+  }
+
+  const stack: NonNullable<ExtractedContext['stack']> = {};
+  if (found.database.size) {stack.database = joinSlot(found.database);}
+  if (found.cache.size) {stack.cache = joinSlot(found.cache);}
+  if (found.search.size) {stack.search = joinSlot(found.search);}
+  if (found.storage.size) {stack.storage = joinSlot(found.storage);}
+  if (found.runtime.size) {stack.runtime = `Docker Compose (${joinSlot(found.runtime)})`;}
+  if (Object.keys(stack).length === 0 && !found.runtime.size) {
+    // compose present but no recognised infra — still a real hosting fact
+    return { stack: { hosting: 'Docker Compose' } };
+  }
+  stack.hosting = 'Docker Compose';
+  return { stack };
+}

--- a/src/interrogate/env.ts
+++ b/src/interrogate/env.ts
@@ -1,0 +1,24 @@
+/**
+ * .env.example interrogation — where secrets live.
+ *
+ * A repo that ships `.env.example` (or `.env.sample`) is telling you: secrets go
+ * in `.env`, this file is the template. Fills `security.secrets` + `.example`.
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import type { ExtractedContext } from './types.js';
+
+const CANDIDATES = [
+  '.env.example', '.env.sample', '.env.template', '.env.dist',
+  'env.example', '.env.local.example',
+];
+
+export function interrogateEnv(dir: string): ExtractedContext {
+  for (const rel of CANDIDATES) {
+    if (existsSync(join(dir, rel))) {
+      return { security: { secrets: '.env', example: rel } };
+    }
+  }
+  return {};
+}

--- a/src/interrogate/index.ts
+++ b/src/interrogate/index.ts
@@ -1,36 +1,55 @@
 /**
  * Repo interrogation orchestrator — runs all extractors and merges results.
  *
- * Order of precedence: extractors that run first WIN (their non-empty values
- * are kept; later extractors fill only empties). README is highest-precedence
- * because its prose is most likely to be hand-curated; manifest fields
- * (Cargo.toml description, package.json description) are fallbacks.
+ * Two classes of extractor:
+ *   - PROSE (README, Cargo.toml description) → `project.goal` + `human_context`.
+ *     README wins on overlap because its prose is most likely hand-curated.
+ *   - FILE-FACTS (docker-compose services, Makefile targets, .env.example) →
+ *     `stack.*` + `commands.*` + `security.*`. These are ground truth pulled
+ *     straight from config — they win over README guesses and over the
+ *     presence-only detectors in scanner.ts (wired in assemble.ts).
  *
- * The orchestrator never overwrites with empty — only fills empties.
+ * The orchestrator never overwrites with a non-empty value — earlier extractors
+ * win; later ones fill empties only.
  */
 
 import type { ExtractedContext } from './types.js';
 import { interrogateReadme } from './readme.js';
 import { interrogateCargo } from './cargo.js';
+import { interrogateCompose } from './compose.js';
+import { interrogateBuildFiles } from './build-files.js';
+import { interrogateEnv } from './env.js';
 
 export type { ExtractedContext } from './types.js';
 export { interrogateReadme } from './readme.js';
 export { interrogateCargo } from './cargo.js';
+export { interrogateCompose } from './compose.js';
+export { interrogateBuildFiles } from './build-files.js';
+export { interrogateEnv } from './env.js';
 
 /** Merge `b` into `a` — only fill empties in `a`, never overwrite. */
 function mergeFillEmpty(a: ExtractedContext, b: ExtractedContext): ExtractedContext {
   const out: ExtractedContext = {
     project: { ...(b.project ?? {}), ...(a.project ?? {}) },
     human_context: { ...(b.human_context ?? {}), ...(a.human_context ?? {}) },
+    stack: { ...(b.stack ?? {}), ...(a.stack ?? {}) },
+    commands: { ...(b.commands ?? {}), ...(a.commands ?? {}) },
+    security: { ...(b.security ?? {}), ...(a.security ?? {}) },
   };
-  // Strip empties for clean equality semantics
-  if (out.project && Object.keys(out.project).length === 0) {delete out.project;}
-  if (out.human_context && Object.keys(out.human_context).length === 0) {delete out.human_context;}
+  // Strip empty sub-objects for clean equality semantics.
+  for (const k of ['project', 'human_context', 'stack', 'commands', 'security'] as const) {
+    if (out[k] && Object.keys(out[k] as object).length === 0) {delete out[k];}
+  }
   return out;
 }
 
 /** Run all repo interrogators and return merged context. */
 export function interrogateRepo(dir: string): ExtractedContext {
-  // README wins on overlapping slots; Cargo.toml fills any remaining empties.
-  return mergeFillEmpty(interrogateReadme(dir), interrogateCargo(dir));
+  return [
+    interrogateReadme(dir),   // prose — highest precedence for goal + 6Ws
+    interrogateCargo(dir),
+    interrogateCompose(dir),  // file-facts — stack.*
+    interrogateBuildFiles(dir), // file-facts — commands.*
+    interrogateEnv(dir),      // file-facts — security.*
+  ].reduce(mergeFillEmpty, {} as ExtractedContext);
 }

--- a/src/interrogate/readme.ts
+++ b/src/interrogate/readme.ts
@@ -156,6 +156,9 @@ export function interrogateReadme(dir: string): ExtractedContext {
   } catch {
     return {};
   }
+  // HTML comment blocks (asset notes, TODO markers, marketing briefs) are not
+  // prose — strip before any extraction so their text can't seed a slot.
+  content = content.replace(/<!--[\s\S]*?-->/g, '');
 
   const result: ExtractedContext = {};
 

--- a/src/interrogate/types.ts
+++ b/src/interrogate/types.ts
@@ -36,6 +36,23 @@ export interface ExtractedContext {
     /** Approach — "## Architecture" / "## How it works" */
     how?: string;
   };
+  /** Stack facts pulled from real config files (docker-compose services, …).
+   *  Higher-precedence than README prose or presence-only guesses for these. */
+  stack?: {
+    database?: string;
+    cache?: string;
+    search?: string;
+    storage?: string;
+    hosting?: string;
+    runtime?: string;
+  };
+  /** Real project commands from Makefile / justfile / Taskfile targets. */
+  commands?: Record<string, string>;
+  /** Secrets handling — from .env.example / .env.sample presence. */
+  security?: {
+    secrets?: string;
+    example?: string;
+  };
 }
 
 /** Confidence threshold rules for extracted text — empty if violated */

--- a/tests/detect/new-types.test.ts
+++ b/tests/detect/new-types.test.ts
@@ -382,3 +382,64 @@ describe('WJTTC ENGINE: Cargo [[bin]] cli detection (xai-faf-rust shape)', () =>
     expect(r.type).not.toBe('cli');
   });
 });
+
+describe('WJTTC ENGINE: polyglot — sibling app dirs (Facts Edition)', () => {
+  function mkSub(name: string, files: Record<string, string>): void {
+    mkdirSync(join(dir, name), { recursive: true });
+    for (const [f, body] of Object.entries(files)) {
+      const p = join(dir, name, f);
+      mkdirSync(join(p, '..'), { recursive: true });
+      writeFileSync(p, body);
+    }
+  }
+
+  test('Django + React + Go siblings → fullstack, found lists the dirs', () => {
+    pkg({ private: true, devDependencies: { husky: '^9' } }); // tooling-only root
+    mkSub('backend', { 'manage.py': '# django', 'pyproject.toml': '[project]\nname="be"\ndependencies=["django"]\n' });
+    mkSub('web', { 'package.json': JSON.stringify({ name: 'web', dependencies: { react: '^18', 'react-dom': '^18' } }) });
+    mkSub('gateway', { 'go.mod': 'module gateway\n\ngo 1.23\n' });
+    const r = detectProjectTypeWithRationale(dir);
+    expect(r.type).toBe('fullstack');
+    expect(r.found.join(' ')).toMatch(/polyglot:/);
+    expect(r.found.join(' ')).toMatch(/backend\/ \(Python\)/);
+    expect(r.found.join(' ')).toMatch(/gateway\/ \(Go\)/);
+  });
+
+  test('Rails api + Vue client → fullstack', () => {
+    pkg({ private: true });
+    mkSub('api', { 'Gemfile': "source 'https://rubygems.org'\ngem 'rails'\n", 'config.ru': 'run App' });
+    mkSub('client', { 'package.json': JSON.stringify({ name: 'client', dependencies: { vue: '^3' } }) });
+    const r = detectProjectTypeWithRationale(dir);
+    expect(r.type).toBe('fullstack');
+  });
+
+  test('NEG — npm workspaces root is NOT polyglot (existing stages own it)', () => {
+    pkg({ private: true, workspaces: ['packages/*'] });
+    mkSub('services', { 'pyproject.toml': '[project]\nname="s"\ndependencies=["fastapi"]\n' });
+    mkSub('ui', { 'package.json': JSON.stringify({ name: 'ui', dependencies: { react: '^18' } }) });
+    const r = detectProjectTypeWithRationale(dir);
+    expect(r.found.join(' ')).not.toMatch(/polyglot:/);
+  });
+
+  test('NEG — single backend dir only → not polyglot', () => {
+    pkg({ private: true });
+    mkSub('server', { 'pyproject.toml': '[project]\nname="s"\ndependencies=["fastapi"]\n' });
+    const r = detectProjectTypeWithRationale(dir);
+    expect(r.found.join(' ')).not.toMatch(/polyglot:/);
+  });
+
+  test('NEG — two dirs, same language, no frontend → not polyglot', () => {
+    pkg({ private: true });
+    mkSub('svc-a', { 'go.mod': 'module a\n\ngo 1.23\n' });
+    mkSub('svc-b', { 'go.mod': 'module b\n\ngo 1.23\n' });
+    const r = detectProjectTypeWithRationale(dir);
+    expect(r.found.join(' ')).not.toMatch(/polyglot:/);
+  });
+
+  test('NEG — bare husky-only root, no sibling manifests → library fallback', () => {
+    pkg({ private: true, devDependencies: { husky: '^9', 'lint-staged': '^15' } });
+    mkdirSync(join(dir, 'scripts'), { recursive: true });
+    const r = detectProjectTypeWithRationale(dir);
+    expect(r.type).toBe('library');
+  });
+});

--- a/tests/interrogate/build-files.test.ts
+++ b/tests/interrogate/build-files.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { interrogateBuildFiles } from '../../src/interrogate/build-files.js';
+
+let dir: string;
+beforeEach(() => { dir = join(tmpdir(), `faf-bf-${Date.now()}-${Math.random().toString(36).slice(2)}`); mkdirSync(dir, { recursive: true }); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe('ENGINE: interrogateBuildFiles — real project commands', () => {
+  test('root Makefile targets → make <target>', () => {
+    writeFileSync(join(dir, 'Makefile'), 'build:\n\tgo build\ntest:\n\tgo test ./...\nlint:\n\tgolangci-lint run\n');
+    const r = interrogateBuildFiles(dir);
+    expect(r.commands).toEqual({ test: 'make test', build: 'make build', lint: 'make lint' });
+  });
+
+  test('check-all wins the lint slot over a bare lint target', () => {
+    writeFileSync(join(dir, 'Makefile'), 'test:\n\tpytest\nlint:\n\truff\ncheck-all: lint mypy test\n');
+    const r = interrogateBuildFiles(dir);
+    expect(r.commands?.lint).toBe('make check-all');
+  });
+
+  test('nested backend Makefile → cd <dir> && make ...', () => {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'root', devDependencies: { husky: '^9' } }));
+    mkdirSync(join(dir, 'futureagi'), { recursive: true });
+    writeFileSync(join(dir, 'futureagi', 'manage.py'), '# django');
+    writeFileSync(join(dir, 'futureagi', 'Makefile'), 'test:\n\tpytest\ncheck-all: test\n');
+    const r = interrogateBuildFiles(dir);
+    expect(r.commands?.test).toBe('cd futureagi && make test');
+    expect(r.commands?.lint).toBe('cd futureagi && make check-all');
+  });
+
+  test('the primary backend Makefile beats a secondary service one', () => {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'root' }));
+    mkdirSync(join(dir, 'gateway'), { recursive: true });
+    writeFileSync(join(dir, 'gateway', 'go.mod'), 'module g\n\ngo 1.23\n');
+    writeFileSync(join(dir, 'gateway', 'Makefile'), 'build:\n\tgo build\ntest:\n\tgo test\nlint:\n\tvet\n');
+    mkdirSync(join(dir, 'backend'), { recursive: true });
+    writeFileSync(join(dir, 'backend', 'manage.py'), '# django');
+    writeFileSync(join(dir, 'backend', 'Makefile'), 'test:\n\tpytest\ncheck-all: test\n');
+    const r = interrogateBuildFiles(dir);
+    expect(r.commands?.test).toBe('cd backend && make test');
+  });
+
+  test('justfile targets → just <target>', () => {
+    writeFileSync(join(dir, 'justfile'), 'test:\n    cargo test\nbuild:\n    cargo build\n');
+    const r = interrogateBuildFiles(dir);
+    expect(r.commands?.test).toBe('just test');
+  });
+
+  test('no build file → empty', () => {
+    expect(interrogateBuildFiles(dir)).toEqual({});
+  });
+});

--- a/tests/interrogate/compose.test.ts
+++ b/tests/interrogate/compose.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { interrogateCompose } from '../../src/interrogate/compose.js';
+
+let dir: string;
+beforeEach(() => { dir = join(tmpdir(), `faf-compose-${Date.now()}-${Math.random().toString(36).slice(2)}`); mkdirSync(dir, { recursive: true }); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+const compose = (body: string, name = 'docker-compose.yml') => writeFileSync(join(dir, name), body);
+
+describe('ENGINE: interrogateCompose — services are the stack', () => {
+  test('maps postgres / redis / minio / clickhouse onto slots', () => {
+    compose(`services:
+  db:
+    image: postgres:16-alpine
+  cache:
+    image: redis:7-alpine
+  blobs:
+    image: minio/minio:latest
+  olap:
+    image: clickhouse/clickhouse-server:25.3-alpine
+`);
+    const r = interrogateCompose(dir);
+    expect(r.stack?.database).toMatch(/PostgreSQL/);
+    expect(r.stack?.database).toMatch(/ClickHouse/);
+    expect(r.stack?.cache).toBe('Redis');
+    expect(r.stack?.storage).toMatch(/MinIO/);
+    expect(r.stack?.hosting).toBe('Docker Compose');
+  });
+
+  test('queue images (kafka / rabbitmq / temporal) → runtime note', () => {
+    compose(`services:
+  q:
+    image: rabbitmq:3-management
+  bus:
+    image: apache/kafka:4.1.0
+  wf:
+    image: temporalio/auto-setup:1.29
+`);
+    const r = interrogateCompose(dir);
+    expect(r.stack?.runtime).toMatch(/Kafka/);
+    expect(r.stack?.runtime).toMatch(/RabbitMQ/);
+    expect(r.stack?.runtime).toMatch(/Temporal/);
+  });
+
+  test('vector DBs → search slot', () => {
+    compose(`services:
+  v:
+    image: qdrant/qdrant:latest
+  w:
+    image: semitechnologies/weaviate:1.25.0
+`);
+    const r = interrogateCompose(dir);
+    expect(r.stack?.search).toMatch(/Qdrant/);
+    expect(r.stack?.search).toMatch(/Weaviate/);
+  });
+
+  test('finds compose files one directory deep', () => {
+    mkdirSync(join(dir, 'backend'), { recursive: true });
+    writeFileSync(join(dir, 'backend', 'docker-compose.yml'), 'services:\n  db:\n    image: postgres:16\n');
+    const r = interrogateCompose(dir);
+    expect(r.stack?.database).toMatch(/PostgreSQL/);
+  });
+
+  test('compose with only app images → hosting fact only', () => {
+    compose('services:\n  app:\n    image: myorg/myapp:latest\n');
+    const r = interrogateCompose(dir);
+    expect(r.stack?.hosting).toBe('Docker Compose');
+    expect(r.stack?.database).toBeUndefined();
+  });
+
+  test('no compose file → empty', () => {
+    expect(interrogateCompose(dir)).toEqual({});
+  });
+});

--- a/tests/wjttc/relentless.test.ts
+++ b/tests/wjttc/relentless.test.ts
@@ -169,3 +169,41 @@ describe('WJTTC ENGINE: Relentless provenance (the auditable form)', () => {
     expect(relentlessContextDetailed(dir)).toEqual({});
   });
 });
+
+describe('WJTTC BRAKE: README noise is not prose (Facts Edition)', () => {
+  test('HTML comment blocks never seed a slot', () => {
+    readme([
+      '<!--',
+      '  MARKETING NOTES: asset budget < 12 MB. Ship light + dark variants.',
+      '  All images live under .github/assets/.',
+      '-->',
+      '# My Project',
+      '',
+      '## About',
+      '',
+      'A real description of what the project actually does for its users.',
+    ].join('\n'));
+    const ctx = relentlessContext(dir);
+    expect(ctx.what ?? '').not.toMatch(/asset budget|MARKETING NOTES/);
+  });
+
+  test('link-list section body (roadmap link row) is rejected for `when`', () => {
+    readme([
+      '# P', '',
+      '## Roadmap', '',
+      '[Vote on the roadmap](https://x.com/roadmap) · [Discussions](https://x.com/d) · [Releases](https://x.com/r) · [Changelog](https://x.com/c)',
+    ].join('\n'));
+    const ctx = relentlessContext(dir);
+    expect(ctx.when ?? '').not.toMatch(/https?:\/\//);
+  });
+
+  test('toolingRoot skips package.json-sourced context (polyglot repo)', () => {
+    pkg({ description: 'Repo-level tooling (husky + lint-staged). App code lives in frontend/ and backend/.' });
+    readme('# P\n\n## Why\n\nBecause production agents need a shared definition of done.\n');
+    const withPkg = relentlessContext(dir);
+    const noPkg = relentlessContext(dir, { toolingRoot: true });
+    expect(withPkg.what ?? '').toMatch(/husky/);
+    expect(noPkg.what ?? '').not.toMatch(/husky/);
+    expect(noPkg.why ?? '').toMatch(/shared definition/); // README still flows
+  });
+});


### PR DESCRIPTION
## What

`faf git` / `faf init` were **root-only**: a sibling-dir polyglot repo (Django + React + Go, no npm workspace) fell to `type: library` / `main_language: JavaScript` / `# found: no classifying signals`, and `faf git` leaned on weak README prose while never reading the tree it clones.

### Polyglot honesty — `src/detect/scanner.ts`, `stack.ts`
- `detectSubdirStacks` / `detectPolyglotSignal` / `detectPolyglotLanguage` — shallow sibling scan. ≥2 app dirs + ≥2 languages + a frontend AND a backend → **`fullstack`** (existing type, 21 slots — **no new app-type; monorepo/33-slot is out of scope, that's xai-faf-rust**), with an aggregated `main_language` and a `# found: polyglot: dir/ (Lang), …` rationale.
- The tooling-shell root `package.json` no longer seeds `project.goal` / `human_context.what` for a polyglot repo.

### Fact-extraction interrogators — `src/interrogate/`
- **`compose.ts`** — `docker-compose*.yml` service images → `stack.database` / `cache` / `search` / `storage` / `runtime` (root + one dir deep).
- **`build-files.ts`** — `Makefile` / `justfile` / `Taskfile` targets → `commands.{test,build,lint}`, nested-dir aware (`cd futureagi && make test`), `check-all` wins the lint slot.
- **`env.ts`** — `.env.example` → `security.{secrets,example}`.
- `assemble.ts` — file-facts **win** over root-only presence guesses; prose fills empties.

### README quality
- Strip `<!-- … -->` comment blocks before extraction (both readers).
- Reject link-list section bodies (a roadmap row of markdown links is not prose).

## Result — `faf git future-agi/future-agi`

| | before | after |
|-|-|-|
| `type` | `library` | `fullstack` |
| `main_language` | `JavaScript` | `Python (Django · backend); Go (backend); TypeScript (React · frontend)` |
| `stack.database` | `""` | `PostgreSQL · ClickHouse` |
| `commands.test` | — | `cd futureagi && make test` |

## Verified
- `bun test` — 1384/1384 (2 new suites + polyglot / relentless cases; one `faf git` network test is intermittently flaky — passes on re-run)
- `bun run lint` — 0 errors (202 warnings; +5 complexity on new helpers, consistent with the file)
- `bun run build` — clean
- Regression: `facebook/react` + `vercel/turborepo` still `monorepo-root`; single-stack repos unchanged.

Surfaced by future-agi/future-agi#2443 / #2482.