### PR TITLE
feat: faf export --llms writes project llms.txt from authored 6Ws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`faf export --llms`** — writes `llms.txt` from `project.faf` (llmstxt.org shape). Opt-in, like `--grok` — not on bare `faf export` / `--all`. Filled 6Ws only; stack, commands, and empty who/why are omitted. A view, not a format.
+
 ### Changed
 - **`faf hooks --install` and `faf diff --install` wire `faf-cli`, not the `faf` alias.** The generated pre-commit hook and `diff.faf.command` now call `faf-cli hooks-run` / `faf-cli diff-driver` — `faf-cli` is the canonical bin (installed alongside `faf` by the same package) and can't be shadowed by another `faf` on PATH.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,6 +182,7 @@ program
   .option('--gemini', 'Author GEMINI.md')
   .option('--copilot', 'Author .github/copilot-instructions.md (GitHub Copilot)')
   .option('--grok', 'Wire grok-faf-mcp into .grok/config.toml')
+  .option('--llms', 'Author llms.txt (llmstxt.org view of authored 6Ws — opt-in)')
   .option('--conductor', 'Author conductor config')
   .option('--html', 'Author project.html (visual render of project.faf)')
   .option('--card', 'Author MCP Server Card (.well-known/mcp/server-card) with the FAF context-block')
@@ -357,6 +358,7 @@ program.command('agents', { hidden: true }).action(() => exportCommand({ agents:
 program.command('cursor', { hidden: true }).action(() => exportCommand({ cursor: true }));
 program.command('gemini', { hidden: true }).action(() => exportCommand({ gemini: true }));
 program.command('grok', { hidden: true }).action(() => exportCommand({ grok: true }));
+program.command('llms', { hidden: true }).action(() => exportCommand({ llms: true }));
 program.command('validate', { hidden: true }).action((file: string) => checkCommand(file));
 program.command('yolo', { hidden: true }).action(() => initCommand({ yolo: true }));
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -7,6 +7,7 @@ import { writeCursorrules } from '../interop/cursorrules.js';
 import { writeGeminiMd } from '../interop/gemini.js';
 import { writeCopilotInstructions } from '../interop/copilot-instructions.js';
 import { writeGrokConfig } from '../interop/grok.js';
+import { writeLlmsTxt } from '../interop/llms.js';
 import { writeProjectHtml } from '../interop/projecthtml.js';
 import { writeServerCard } from '../interop/servercard.js';
 import { scoreFafYaml } from '../core/scorer.js';
@@ -18,6 +19,7 @@ export interface ExportOptions {
   gemini?: boolean;
   copilot?: boolean;
   grok?: boolean;
+  llms?: boolean;
   conductor?: boolean;
   html?: boolean;
   card?: boolean;
@@ -43,6 +45,7 @@ export function exportCommand(options: ExportOptions = {}): void {
       !options.gemini &&
       !options.copilot &&
       !options.grok &&
+      !options.llms &&
       !options.conductor &&
       !options.html &&
       !options.card);
@@ -76,6 +79,14 @@ export function exportCommand(options: ExportOptions = {}): void {
   if (options.grok) {
     const status = writeGrokConfig(dir, data);
     console.log(`  .grok/config.toml (${status})`);
+  }
+
+  // Opt-in only: project llms.txt (llmstxt.org view of authored 6Ws).
+  // Origin crawlers vs repo agents are different rooms — never a side effect
+  // of bare `faf export` / `--all`.
+  if (options.llms) {
+    writeLlmsTxt(dir, data);
+    console.log(`  llms.txt`);
   }
 
   if (exportAll || options.html) {

--- a/src/interop/llms.ts
+++ b/src/interop/llms.ts
@@ -1,0 +1,74 @@
+import { join } from 'path';
+import type { FafData } from '../core/types.js';
+import { injectFafBlock } from './inject.js';
+import { filled } from './labels.js';
+
+/** Table-of-8 human 6Ws — public WHAT/WHY, never stack/HOW. */
+const SIX_WS: ReadonlyArray<{ key: string; heading: string }> = [
+  { key: 'who', heading: 'Who' },
+  { key: 'what', heading: 'What' },
+  { key: 'why', heading: 'Why' },
+  { key: 'where', heading: 'Where' },
+  { key: 'when', heading: 'When' },
+  { key: 'how', heading: 'How' },
+];
+
+/** A human fact — populated, not slotignored, not none/N/A. */
+function humanFact(v: unknown): string | null {
+  if (!filled(v)) {return null;}
+  const t = v.trim();
+  if (/^(none|n\/a)$/i.test(t)) {return null;}
+  return t;
+}
+
+function scalar(map: Record<string, unknown> | undefined, key: string): string | null {
+  if (!map) {return null;}
+  return humanFact(map[key]);
+}
+
+/**
+ * Generate `llms.txt` from project.faf — llmstxt.org shape (H1, optional
+ * blockquote, optional sections). A view, not a format.
+ *
+ * Filled 6Ws only. Stack, commands, score, and empty human slots are omitted.
+ * Blank who/why stay blank — never paraphrased from the README.
+ */
+export function generateLlmsTxt(data: FafData): string {
+  const lines: string[] = [];
+  const name = humanFact(data.project?.name) ?? 'Project';
+  const goal = humanFact(data.project?.goal);
+
+  lines.push(`# ${name}`);
+  lines.push('');
+  if (goal) {
+    lines.push(`> ${goal}`);
+    lines.push('');
+  }
+
+  const hc = data.human_context;
+  for (const { key, heading } of SIX_WS) {
+    const value = scalar(hc, key);
+    if (!value) {continue;}
+    lines.push(`## ${heading}`);
+    lines.push('');
+    lines.push(value);
+    lines.push('');
+  }
+
+  const homepage =
+    scalar(data.project as Record<string, unknown> | undefined, 'homepage') ??
+    scalar(data.project as Record<string, unknown> | undefined, 'url');
+  if (homepage && /^(https?:)?\/\//i.test(homepage)) {
+    lines.push('## Links');
+    lines.push('');
+    lines.push(`- [Homepage](${homepage})`);
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+/** Write llms.txt — non-destructive: injects/updates the faf block, preserves the rest. */
+export function writeLlmsTxt(dir: string, data: FafData): void {
+  injectFafBlock(join(dir, 'llms.txt'), generateLlmsTxt(data));
+}

--- a/tests/interop/inject.test.ts
+++ b/tests/interop/inject.test.ts
@@ -12,6 +12,7 @@ import { writeAgentsMd } from '../../src/interop/agents.js';
 import { writeGeminiMd } from '../../src/interop/gemini.js';
 import { writeCursorrules } from '../../src/interop/cursorrules.js';
 import { writeClaudeMd, generateClaudeMd } from '../../src/interop/claude.js';
+import { writeLlmsTxt } from '../../src/interop/llms.js';
 
 function tmp(): string { return mkdtempSync(join(tmpdir(), 'faf-inject-')); }
 const DATA: any = {
@@ -119,5 +120,14 @@ describe('TYRE: interop writers — enhance, never replace', () => {
     writeClaudeMd(d, generateClaudeMd(DATA));
     const out = readFileSync(join(d, 'CLAUDE.md'), 'utf-8');
     expect(out).toContain(MARK);
+  });
+
+  test('writeLlmsTxt preserves an existing llms.txt', () => {
+    const d = tmp();
+    writeFileSync(join(d, 'llms.txt'), `# Mine\n${MARK}\nnotes\n`);
+    writeLlmsTxt(d, DATA);
+    const out = readFileSync(join(d, 'llms.txt'), 'utf-8');
+    expect(out).toContain(MARK);
+    expect(out).toContain('demo');
   });
 });

--- a/tests/wjttc/llms-export.test.ts
+++ b/tests/wjttc/llms-export.test.ts
@@ -1,0 +1,157 @@
+/**
+ * WJTTC — faf export --llms (project llms.txt).
+ *
+ * A view of authored 6Ws in llmstxt.org shape. Not a format. Opt-in door.
+ *
+ * BRAKE  — empty 6Ws omitted; stack/commands never dumped; none/N/A not written
+ * ENGINE — H1 + goal blockquote; filled who/why present; homepage link
+ * AERO   — deterministic; --llms alone does not dump AGENTS.md
+ * TYRE   — live CLI: --llms writes; bare export and --all do not
+ * PIT    — existing llms.txt hand text preserved (inject)
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { execSync } from 'child_process';
+import { generateLlmsTxt, writeLlmsTxt } from '../../src/interop/llms.js';
+import { FAF_START } from '../../src/interop/inject.js';
+import type { FafData } from '../../src/core/types.js';
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'faf-llms-'));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const DATA: FafData = {
+  project: {
+    name: 'demo',
+    goal: 'A small API',
+    main_language: 'TypeScript',
+    homepage: 'https://example.com',
+  },
+  stack: { backend: 'Express', build: 'npm' },
+  commands: { test: 'npm test' },
+  human_context: { who: 'API authors', why: 'Stop guessing the audience' },
+};
+
+describe('WJTTC BRAKE: llms.txt does not invent or dump HOW', () => {
+  test('empty 6Ws are omitted — not none, not paraphrased', () => {
+    const out = generateLlmsTxt({
+      project: { name: 'blank', goal: 'Has a goal' },
+      human_context: { who: '', why: 'slotignored', what: 'none', how: 'N/A' },
+    });
+    expect(out).toContain('# blank');
+    expect(out).toContain('> Has a goal');
+    expect(out).not.toMatch(/^## Who/m);
+    expect(out).not.toMatch(/^## Why/m);
+    expect(out).not.toMatch(/^## What/m);
+    expect(out).not.toMatch(/^## How/m);
+    expect(out.toLowerCase()).not.toContain('none');
+    expect(out.toLowerCase()).not.toContain('n/a');
+    expect(out).not.toContain('slotignored');
+  });
+
+  test('stack and commands never appear', () => {
+    const out = generateLlmsTxt(DATA);
+    expect(out).not.toContain('Express');
+    expect(out).not.toContain('npm test');
+    expect(out).not.toContain('stack');
+    expect(out).not.toContain('TypeScript');
+  });
+});
+
+describe('WJTTC ENGINE: llmstxt.org shape from authored facts', () => {
+  test('H1, goal blockquote, filled Who/Why, homepage link', () => {
+    const out = generateLlmsTxt(DATA);
+    expect(out.startsWith('# demo\n')).toBe(true);
+    expect(out).toContain('> A small API');
+    expect(out).toContain('## Who');
+    expect(out).toContain('API authors');
+    expect(out).toContain('## Why');
+    expect(out).toContain('Stop guessing the audience');
+    expect(out).toContain('## Links');
+    expect(out).toContain('- [Homepage](https://example.com)');
+    expect(out).not.toMatch(/^## What/m);
+  });
+
+  test('name-only project still emits a valid H1', () => {
+    const out = generateLlmsTxt({ project: { name: 'just-a-name' } });
+    expect(out).toBe('# just-a-name\n');
+  });
+});
+
+describe('WJTTC AERO: deterministic + --llms is not exportAll', () => {
+  test('two calls are byte-identical', () => {
+    expect(generateLlmsTxt(DATA)).toBe(generateLlmsTxt(DATA));
+  });
+});
+
+describe('WJTTC PIT: existing llms.txt is enhanced, never replaced', () => {
+  test('hand-written tail survives writeLlmsTxt', () => {
+    const mark = '## HAND-WRITTEN — MUST SURVIVE';
+    writeFileSync(join(dir, 'llms.txt'), `# Mine\n${mark}\nnotes\n`);
+    writeLlmsTxt(dir, DATA);
+    const out = readFileSync(join(dir, 'llms.txt'), 'utf-8');
+    expect(out).toContain(mark);
+    expect(out).toContain('# demo');
+    expect(out.split(FAF_START).length - 1).toBe(1);
+  });
+});
+
+describe('WJTTC TYRE: live CLI — opt-in guard', () => {
+  const cli = join(__dirname, '../../src/cli.ts');
+  const run = (cmd: string) =>
+    execSync(`bun ${cli} ${cmd}`, { cwd: dir, encoding: 'utf-8', timeout: 30000 });
+
+  beforeEach(() => {
+    writeFileSync(
+      join(dir, 'project.faf'),
+      [
+        'faf_version: "3.3"',
+        'project:',
+        '  name: wjttc-llms',
+        '  goal: live llms.txt grip',
+        '  homepage: https://faf.one',
+        'human_context:',
+        '  who: maintainers',
+        'stack:',
+        '  backend: Rust',
+        '',
+      ].join('\n'),
+    );
+  });
+
+  test('`faf export --llms` writes llms.txt end-to-end', () => {
+    run('export --llms');
+    const out = readFileSync(join(dir, 'llms.txt'), 'utf-8');
+    expect(out).toContain('# wjttc-llms');
+    expect(out).toContain('> live llms.txt grip');
+    expect(out).toContain('## Who');
+    expect(out).toContain('maintainers');
+    expect(out).toContain('[Homepage](https://faf.one)');
+    expect(out).not.toContain('Rust');
+  });
+
+  test('bare `faf export` does NOT write llms.txt', () => {
+    run('export');
+    expect(existsSync(join(dir, 'llms.txt'))).toBe(false);
+  });
+
+  test('`faf export --all` does NOT write llms.txt', () => {
+    run('export --all');
+    expect(existsSync(join(dir, 'llms.txt'))).toBe(false);
+    expect(existsSync(join(dir, 'AGENTS.md'))).toBe(true);
+  });
+
+  test('`faf export --llms` does NOT dump AGENTS.md', () => {
+    run('export --llms');
+    expect(existsSync(join(dir, 'llms.txt'))).toBe(true);
+    expect(existsSync(join(dir, 'AGENTS.md'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description

Opt-in `faf export --llms` projects authored 6Ws from `project.faf` into `llms.txt` (llmstxt.org shape). Site door vs repo door — same human facts, neither file owns who/why.

## Type of Change

- [x] Command enhancement (improves existing command)
- [x] Test coverage improvement

## Changes Made

- `src/interop/llms.ts` — view, not a format. H1 + goal blockquote + filled 6Ws only. Stack/commands omitted. `none` / `N/A` / empty / `slotignored` not written.
- `faf export --llms` is opt-in (same family as `--grok`). Bare `export` and `--all` do not write `llms.txt`.
- Non-destructive inject — existing hand text in `llms.txt` is preserved.
- WJTTC tests: BRAKE / ENGINE / AERO / TYRE / PIT.

## Command Changes

### Modified Commands

```bash
faf export --llms
```

Writes `llms.txt` next to `project.faf`. Refresh the managed block; do not treat the file as a second source of truth.

## Testing

- [x] `bun test tests/wjttc/llms-export.test.ts tests/interop/inject.test.ts` — 21 pass
- [x] Live emit from this repo’s Trophy `project.faf` (all 6Ws filled, no stack leak)
- [x] Blank 6W fixture emits name + goal only

## Context

FAF defines. MD instructs. `llms.txt` is a crawler-facing projection of the same ☑s — not a competing format, not on npm until `/pubpro`.