### PR TITLE
docs: add the Awesome Claude Code badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ detected from your real stack, scored, and versioned with your code. No drift. N
 [![IANA vnd.faf+yaml](https://img.shields.io/badge/IANA-vnd.faf%2Byaml-008B8B)](https://www.iana.org/assignments/media-types/application/vnd.faf+yaml)
 [![IANA vnd.fafm+yaml](https://img.shields.io/badge/IANA-vnd.fafm%2Byaml-008B8B)](https://www.iana.org/assignments/media-types/application/vnd.fafm+yaml)
 [![IANA vnd.fafa+yaml](https://img.shields.io/badge/IANA-vnd.fafa%2Byaml-008B8B)](https://www.iana.org/assignments/media-types/application/vnd.fafa+yaml)
+[![Mentioned in Awesome Claude Code](https://awesome.re/mentioned-badge.svg)](https://github.com/hesreallyhim/awesome-claude-code)
 [![downloads](https://img.shields.io/npm/dt/faf-cli?color=008B8B&label=downloads)](https://www.npmjs.com/package/faf-cli)
 [![npm](https://img.shields.io/npm/v/faf-cli?color=00CCFF)](https://www.npmjs.com/package/faf-cli)
 


### PR DESCRIPTION
\`faf-cli\` was merged into [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) (53k★) after validation — issue #119 is the one-time notification offering the badge, and wolfejam's leaning toward using it.

Placed in the PRIME receipts block after the IANA badges — it's an earned recognition (a curated 53k-star list in faf-cli's exact audience), grouped with the receipts rather than the stats.

README-only. Shows on GitHub immediately on merge; rides to npm with the next \`/pubpro cli\` release.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aij9ReMwQeQTVSnYUZ4Qdt