### PR TITLE
chore: regenerate examples/ to the current 3.0 schema

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,72 +1,50 @@
-# FAF Examples
+# FAF examples
 
-Real-world `project.faf` examples for common project types.
-
-## Examples
+Worked `project.faf` files for common project shapes. Each one is current-schema
+(`faf_version: "3.0"`) and scores **Trophy (100%)** — copy one, swap in your own
+values, and `faf score` tells you what's still missing.
 
 | File | Type | Stack |
 |------|------|-------|
-| `react-dashboard.faf` | React app | React + Vite + Postgres + Vercel |
-| `node-api.faf` | REST API | Fastify + Postgres + Redis + AWS |
-| `python-ml.faf` | ML pipeline | FastAPI + PyTorch + Qdrant + Modal |
-| `svelte-saas.faf` | SaaS app | SvelteKit + Postgres + Cloudflare |
-| `cli-tool.faf` | CLI tool | Go + Homebrew |
-| `monorepo.faf` | Monorepo | Turborepo + Next.js + Fastify |
+| `react-dashboard.faf` | Web app | React · Vite · Tailwind · Postgres · Vercel |
+| `node-api.faf` | REST API | Fastify · Postgres · Redis · S3 · AWS Lambda |
+| `python-ml.faf` | ML pipeline | FastAPI · PyTorch · Qdrant · Modal |
+| `svelte-saas.faf` | SaaS app | SvelteKit · Tailwind · Drizzle · Postgres · Cloudflare |
+| `cli-tool.faf` | CLI tool | Go · Homebrew (frontend/backend slots `slotignored`) |
+| `monorepo.faf` | Monorepo | Turborepo · pnpm · Next.js · Fastify · Postgres |
 
-## Using These Examples
-
-Copy and customize for your project:
+## Using an example
 
 ```bash
-# Copy an example
-cp examples/react-dashboard.faf project.faf
-
-# Edit for your project
-# (update name, goal, stack, human_context)
-
-# Verify your score
-faf score
-
-# Sync with CLAUDE.md
-faf bi-sync
+cp examples/react-dashboard.faf project.faf   # pick the closest shape
+# edit name / version / goal / stack / human_context for your project
+faf score                                     # see how complete it is
+faf sync                                      # keep it in step with CLAUDE.md
 ```
 
-## Structure
+## Shape
 
-Every `project.faf` has three core sections:
+Current `project.faf` (`3.0`) — the examples show all of it:
 
 ```yaml
-project:
-  name: "your-project"
-  goal: "What this project does"
-  main_language: typescript
-
-stack:
-  # Your technology choices
-  frontend: react
-  backend: node
-  database: postgres
-
-human_context:
-  # The information only you know
-  who: "Who is building this"
-  what: "What you're building"
-  why: "Why it matters"
-  where: "Where it runs"
-  when: "Timeline and milestones"
-  how: "How it works"
+faf_version: "3.0"
+project:            # name, version, goal, main_language, type
+commands:           # install / build / dev / test / lint
+key_files:          # the paths an agent should read first
+instant_context:    # a one-glance summary — what / stack / key files
+stack:              # the 21 slots — a real value, or `slotignored` when it genuinely doesn't apply
+human_context:      # the six Ws — who / what / why / where / when / how (only you know these)
 ```
 
-## Creating Your Own
+A `slotignored` slot counts as answered — a CLI with no frontend still scores Trophy.
+
+## Starting from your own repo instead
 
 ```bash
-# Auto-detect your stack
-faf auto
-
-# Or start from scratch
-faf init
+faf auto     # detect the stack, fill what's observable
+faf init     # or start from a blank interview
 ```
 
 ---
 
-*.faf is the format. `project.faf` is the file. 100% AI Readiness is the result.*
+*`.faf` is the format. `project.faf` is the file. 100% AI readiness is the result.*

--- a/examples/cli-tool.faf
+++ b/examples/cli-tool.faf
@@ -1,35 +1,55 @@
-# CLI Tool Example
-# Database migration management tool
+# CLI tool — database migration manager (Go)
+# Copy to project.faf and edit for your project. Run `faf score` to check completeness.
+# A CLI has no frontend/backend/hosting — `slotignored` is the honest value, and it still scores Trophy.
 
-faf_version: 4.0.0
-generated: 2025-01-24
-
+faf_version: "3.0"
 project:
-  name: "migrator"
-  goal: "Zero-downtime database migrations with rollback support"
-  main_language: go
-
+  name: migrator
+  version: "0.9.0"
+  goal: "Zero-downtime database migrations with automatic rollback"
+  main_language: Go
+  type: cli
+commands:
+  build: go build ./...
+  test: go test ./...
+  lint: golangci-lint run
+  install: go install .
+key_files:
+  - main.go
+  - cmd/
+  - internal/migrate/
+  - internal/rollback/
+  - go.mod
+instant_context:
+  what_building: Database schema-migration CLI with rollback
+  tech_stack: Go · Postgres / MySQL / SQLite · distributed via Homebrew
+  key_files:
+    - cmd/
+    - internal/migrate/
 stack:
-  build: go_modules
-  distribution: homebrew
-  ci: github_actions
-  supported_dbs:
-    - postgres
-    - mysql
-    - sqlite
-  config_format: yaml
-
+  frontend: slotignored
+  css_framework: slotignored
+  ui_library: slotignored
+  state_management: slotignored
+  backend: slotignored
+  api_type: slotignored
+  runtime: slotignored
+  database: slotignored
+  connection: slotignored
+  hosting: slotignored
+  build: go
+  cicd: github_actions
+  monorepo_tool: slotignored
+  package_manager: go-modules
+  workspaces: slotignored
+  admin: slotignored
+  cache: slotignored
+  search: slotignored
+  storage: slotignored
 human_context:
-  who: "Platform engineering team at mid-size company"
-  what: "CLI tool for managing database schema changes across environments"
-  why: "Existing tools don't support our multi-region, multi-tenant setup"
+  who: "Platform engineering team at a mid-size company"
+  what: "CLI for managing database schema changes across environments"
+  why: "Existing tools don't support the team's multi-region, multi-tenant setup"
   where: "Distributed via Homebrew and direct binary downloads"
-  when: "Internal use for 2 years, now open-sourcing"
+  when: "Internal for ~2 years, now being open-sourced"
   how: "Version-controlled migrations, dry-run mode, automatic rollback on failure"
-
-preferences:
-  quality_bar: zero_data_loss
-  testing: table_driven
-  release: semantic_versioning
-
-# Score: 100% - All slots filled

--- a/examples/monorepo.faf
+++ b/examples/monorepo.faf
@@ -1,45 +1,63 @@
-# Monorepo Example
-# Full-stack e-commerce platform
+# Monorepo — headless e-commerce platform (Turborepo)
+# Copy to project.faf and edit for your project. Run `faf score` to check completeness.
 
-faf_version: 4.0.0
-generated: 2025-01-24
-
+faf_version: "3.0"
 project:
-  name: "shopfront"
-  goal: "Modern e-commerce platform with headless architecture"
-  main_language: typescript
-
+  name: shopfront
+  version: "3.1.0"
+  goal: "Headless commerce with custom storefronts, one codebase per client theme"
+  main_language: TypeScript
+  type: monorepo
+commands:
+  install: pnpm install
+  dev: pnpm dev
+  build: pnpm build
+  test: pnpm test
+  lint: pnpm lint
+key_files:
+  - apps/web/
+  - apps/admin/
+  - apps/api/
+  - packages/ui/
+  - packages/db/
+  - turbo.json
+instant_context:
+  what_building: Headless e-commerce platform, multi-app monorepo
+  tech_stack: Turborepo · pnpm · Next.js · Fastify · Postgres
+  key_files:
+    - apps/web/
+    - packages/ui/
+    - packages/db/
 stack:
+  frontend: nextjs
+  css_framework: tailwind
+  ui_library: shadcn
+  state_management: zustand
+  backend: fastify
+  api_type: rest
+  runtime: node
+  database: postgres
+  connection: prisma
+  hosting: vercel
+  build: turbo
+  cicd: github_actions
   monorepo_tool: turborepo
   package_manager: pnpm
-  workspaces:
-    - apps/web (nextjs storefront)
-    - apps/admin (react admin panel)
-    - apps/api (fastify backend)
-    - packages/ui (shared components)
-    - packages/db (prisma schema)
-    - packages/config (shared configs)
-  frontend: nextjs
+  workspaces: apps/*, packages/*
   admin: react
-  backend: fastify
-  database: postgres
   cache: redis
   search: meilisearch
-  storage: cloudflare_r2
-  hosting: vercel
-  ci: github_actions
-
+  storage: r2
+monorepo:
+  packages_count: 6
+  build_orchestrator: turborepo
+  versioning_strategy: fixed
+  shared_configs: "packages/config (eslint, tsconfig, tailwind)"
+  remote_cache: vercel
 human_context:
-  who: "E-commerce agency building platforms for fashion brands"
-  what: "Headless commerce with custom storefronts for each client"
-  why: "Shopify too limiting, custom builds too expensive to maintain"
-  where: "Vercel (apps), Railway (services), Cloudflare (assets)"
-  when: "3 clients live, 2 in development, targeting 10 by EOY"
-  how: "Shared core, client-specific themes, white-label admin"
-
-preferences:
-  quality_bar: production_grade
-  commit_style: conventional
-  testing: required_for_core
-
-# Score: 100% - All slots filled
+  who: "An e-commerce agency building platforms for fashion brands"
+  what: "Headless commerce with a custom storefront per client, one shared core"
+  why: "Shopify was too limiting; fully custom builds were too expensive to maintain"
+  where: "Vercel (apps), a managed Postgres, Cloudflare R2 (assets)"
+  when: "A handful of clients live, more in development"
+  how: "Shared core packages, client-specific themes, a white-label admin"

--- a/examples/node-api.faf
+++ b/examples/node-api.faf
@@ -1,36 +1,55 @@
-# Node.js REST API Example
-# Payment processing service with Stripe integration
+# Node REST API — payment / billing service
+# Copy to project.faf and edit for your project. Run `faf score` to check completeness.
 
-faf_version: 4.0.0
-generated: 2025-01-24
-
+faf_version: "3.0"
 project:
-  name: "payments-api"
-  goal: "Handle subscription billing, invoices, and payment processing"
-  main_language: typescript
-
+  name: payments-api
+  version: "2.3.0"
+  goal: "Subscription billing, invoicing, and payment processing with multi-currency support"
+  main_language: TypeScript
+  type: api
+commands:
+  install: npm install
+  dev: npm run dev
+  build: npm run build
+  test: npm run test
+  migrate: npm run db:migrate
+key_files:
+  - src/routes/
+  - src/billing/
+  - src/webhooks/
+  - src/db/schema.ts
+  - package.json
+instant_context:
+  what_building: Payment service — subscriptions, invoices, webhooks
+  tech_stack: Fastify · Postgres · Redis · BullMQ · AWS Lambda
+  key_files:
+    - src/billing/
+    - src/webhooks/
 stack:
-  runtime: node
-  framework: fastify
-  database: postgres
-  cache: redis
-  queue: bullmq
-  hosting: aws_lambda
+  frontend: slotignored
+  css_framework: slotignored
+  ui_library: slotignored
+  state_management: slotignored
+  backend: fastify
   api_type: rest
-  documentation: swagger
-
+  runtime: node
+  database: postgres
+  connection: drizzle
+  hosting: aws_lambda
+  build: tsup
+  cicd: github_actions
+  monorepo_tool: slotignored
+  package_manager: npm
+  workspaces: slotignored
+  admin: slotignored
+  cache: redis
+  search: slotignored
+  storage: s3
 human_context:
-  who: "Backend team at fintech startup (3 developers)"
-  what: "Payment service handling $2M+ monthly recurring revenue"
-  why: "Outgrew Stripe-only setup. Need custom billing logic and multi-currency support."
-  where: "AWS (us-east-1, eu-west-1)"
-  when: "Production since Q2 2024, processing 50k+ transactions/month"
-  how: "Stripe for payments, custom logic for invoicing, webhooks for real-time sync"
-
-preferences:
-  quality_bar: zero_runtime_errors
-  testing: required
-  logging: structured_json
-  security: pci_compliant
-
-# Score: 100% - All slots filled
+  who: "Backend team at a fintech startup (3 developers)"
+  what: "Payment service handling multi-currency subscription billing and invoicing"
+  why: "Outgrew a Stripe-only setup — needed custom billing logic and reconciliation"
+  where: "AWS, multi-region (us-east-1, eu-west-1)"
+  when: "In production, ~50k transactions/month"
+  how: "Stripe for card processing, custom logic for invoicing, webhooks for real-time sync"

--- a/examples/python-ml.faf
+++ b/examples/python-ml.faf
@@ -1,36 +1,54 @@
-# Python ML Project Example
-# Document classification and extraction pipeline
+# Python ML pipeline — document classification + extraction
+# Copy to project.faf and edit for your project. Run `faf score` to check completeness.
 
-faf_version: 4.0.0
-generated: 2025-01-24
-
+faf_version: "3.0"
 project:
-  name: "doc-classifier"
-  goal: "Classify and extract structured data from uploaded documents"
-  main_language: python
-
+  name: doc-classifier
+  version: "0.4.0"
+  goal: "Classify legal documents and extract key clauses from uploaded files"
+  main_language: Python
+  type: data-science
+commands:
+  install: uv sync
+  dev: uv run uvicorn app.main:app --reload
+  test: uv run pytest
+  train: uv run python -m app.train
+key_files:
+  - app/main.py
+  - app/classify/
+  - app/extract/
+  - app/train.py
+  - pyproject.toml
+instant_context:
+  what_building: Legal-document classifier + clause extractor
+  tech_stack: FastAPI · PyTorch · sentence-transformers · Qdrant · Modal
+  key_files:
+    - app/classify/
+    - app/extract/
 stack:
-  framework: fastapi
-  ml_framework: pytorch
-  embeddings: sentence_transformers
-  vector_db: qdrant
-  task_queue: celery
-  broker: redis
-  storage: s3
+  frontend: slotignored
+  css_framework: slotignored
+  ui_library: slotignored
+  state_management: slotignored
+  backend: fastapi
+  api_type: rest
+  runtime: python
+  database: postgres
+  connection: sqlalchemy
   hosting: modal
-
+  build: uv
+  cicd: github_actions
+  monorepo_tool: slotignored
+  package_manager: uv
+  workspaces: slotignored
+  admin: slotignored
+  cache: redis
+  search: qdrant
+  storage: s3
 human_context:
-  who: "ML engineering team at legal tech company (2 ML engineers, 1 backend)"
-  what: "Classify legal documents (contracts, NDAs, amendments) and extract key clauses"
-  why: "Lawyers spend 40% of time on document review. Automate the obvious parts."
+  who: "ML engineering team at a legal-tech company (2 ML engineers, 1 backend)"
+  what: "Classify contracts / NDAs / amendments and extract key clauses"
+  why: "Lawyers spend ~40% of their time on document review — automate the obvious parts"
   where: "Modal for inference, S3 for storage, on-prem for training"
-  when: "Beta with 5 law firms, targeting GA in Q2"
-  how: "Fine-tuned BERT for classification, GPT-4 for extraction, human review for edge cases"
-
-preferences:
-  quality_bar: reproducible_results
-  testing: pytest
-  environment: conda
-  gpu: a100
-
-# Score: 100% - All slots filled
+  when: "In beta with a handful of firms, targeting GA next quarter"
+  how: "Fine-tuned encoder for classification, an LLM for extraction, human review on edge cases"

--- a/examples/react-dashboard.faf
+++ b/examples/react-dashboard.faf
@@ -1,36 +1,53 @@
-# React Dashboard Example
-# A real-time metrics dashboard for engineering teams
+# React dashboard — real-time engineering-metrics app
+# Copy to project.faf and edit for your project. Run `faf score` to check completeness.
 
-faf_version: 4.0.0
-generated: 2025-01-24
-
+faf_version: "3.0"
 project:
-  name: "team-metrics"
+  name: team-metrics
+  version: "1.0.0"
   goal: "Real-time dashboard showing engineering team velocity and sprint progress"
-  main_language: typescript
-
+  main_language: TypeScript
+  type: website
+commands:
+  install: npm install
+  dev: npm run dev
+  build: npm run build
+  test: npm run test
+key_files:
+  - src/routes/
+  - src/lib/
+  - src/lib/api/
+  - package.json
+instant_context:
+  what_building: Real-time engineering-velocity dashboard
+  tech_stack: React · Vite · Tailwind · Postgres · Vercel
+  key_files:
+    - src/routes/
+    - src/lib/api/
 stack:
   frontend: react
-  state_management: zustand
   css_framework: tailwind
-  build: vite
+  ui_library: radix
+  state_management: zustand
   backend: node
+  api_type: rest
+  runtime: node
   database: postgres
-  orm: prisma
+  connection: prisma
   hosting: vercel
-  auth: clerk
-
+  build: vite
+  cicd: github_actions
+  monorepo_tool: slotignored
+  package_manager: npm
+  workspaces: slotignored
+  admin: slotignored
+  cache: slotignored
+  search: slotignored
+  storage: slotignored
 human_context:
-  who: "Engineering team at a B2B SaaS startup (12 developers)"
+  who: "Engineering team at a B2B SaaS startup (~12 developers)"
   what: "Internal dashboard replacing spreadsheet-based sprint tracking"
-  why: "Manual reporting takes 10+ hours/week. Need real-time visibility."
-  where: "Vercel (frontend) + Railway (database)"
-  when: "MVP in 2 weeks, v1.0 in 6 weeks"
-  how: "GitHub Issues integration, JIRA sync, automated daily snapshots"
-
-preferences:
-  quality_bar: strict_typescript
-  commit_style: conventional
-  testing: vitest
-
-# Score: 100% - All slots filled
+  why: "Manual reporting took 10+ hours a week — the team needed real-time visibility"
+  where: "Vercel (app) + a managed Postgres"
+  when: "MVP in 2 weeks, v1.0 in 6"
+  how: "GitHub Issues + project-board sync, automated daily snapshots"

--- a/examples/svelte-saas.faf
+++ b/examples/svelte-saas.faf
@@ -1,36 +1,54 @@
-# SvelteKit SaaS Example
-# Multi-tenant project management application
+# SvelteKit SaaS — multi-tenant project management app
+# Copy to project.faf and edit for your project. Run `faf score` to check completeness.
 
-faf_version: 4.0.0
-generated: 2025-01-24
-
+faf_version: "3.0"
 project:
-  name: "projecthub"
-  goal: "Lightweight project management tool for small teams"
-  main_language: typescript
-
+  name: projecthub
+  version: "1.6.2"
+  goal: "Lightweight project management — boards, time tracking, client portals, invoicing"
+  main_language: TypeScript
+  type: website
+commands:
+  install: pnpm install
+  dev: pnpm dev
+  build: pnpm build
+  test: pnpm test
+key_files:
+  - src/routes/
+  - src/lib/server/
+  - src/lib/db/schema.ts
+  - src/hooks.server.ts
+  - package.json
+instant_context:
+  what_building: Multi-tenant project-management SaaS
+  tech_stack: SvelteKit · Tailwind · Drizzle · Postgres · Cloudflare
+  key_files:
+    - src/routes/
+    - src/lib/server/
 stack:
   frontend: sveltekit
   css_framework: tailwind
-  ui_library: shadcn-svelte
-  backend: sveltekit_server
+  ui_library: bits-ui
+  state_management: svelte-stores
+  backend: sveltekit
+  api_type: rpc
+  runtime: cloudflare-workers
   database: postgres
-  orm: drizzle
-  auth: lucia
+  connection: drizzle
   hosting: cloudflare_pages
-  edge: cloudflare_workers
-
+  build: vite
+  cicd: github_actions
+  monorepo_tool: slotignored
+  package_manager: pnpm
+  workspaces: slotignored
+  admin: slotignored
+  cache: slotignored
+  search: slotignored
+  storage: r2
 human_context:
-  who: "Solo founder building for small creative agencies (5-20 people)"
-  what: "Kanban boards, time tracking, client portals, invoicing"
-  why: "Existing tools are too complex or too expensive for small teams"
-  where: "Cloudflare (global edge)"
-  when: "Launched 6 months ago, 200 paying customers, $8k MRR"
-  how: "Freemium model, self-serve onboarding, Stripe for billing"
-
-preferences:
-  quality_bar: fast_first
-  commit_style: conventional
-  deploy: continuous
-
-# Score: 100% - All slots filled
+  who: "Solo founder building for small creative agencies (5–20 people)"
+  what: "Kanban boards, time tracking, client portals, invoicing in one tool"
+  why: "Existing tools are too complex or too expensive for teams this size"
+  where: "Cloudflare — global edge, Postgres via a managed provider"
+  when: "Launched, a few hundred paying customers, growing month over month"
+  how: "Freemium, self-serve onboarding, Stripe for billing"


### PR DESCRIPTION
The 6 example `.faf` files were pinned to the v4.0.0-era format and no longer matched what the CLI produces or accepts.

## Was → is

| | Before | After |
|---|---|---|
| `faf_version` | `4.0.0` | `"3.0"` (canonical — `src/core/version.ts`) |
| `generated:` | hardcoded `2025-01-24` | dropped (CLI doesn't emit it) |
| `stack:` | free-form keys (`build: go_modules`, `supported_dbs:`, `distribution:`) | the named 21-slot stack — real value or `slotignored` |
| `preferences:` | present | dropped (not in the schema) |
| `# Score: 100%` | claimed, actually **48–76%** against the current scorer | no hardcoded claim; each genuinely scores Trophy |
| `commands:` / `key_files:` / `instant_context:` | absent | present, matching the canonical `project.faf` this repo ships |

## Verification

```
examples/cli-tool.faf         valid   TROPHY 100%  11/11 slots
examples/monorepo.faf         valid   TROPHY 100%  21/21 slots
examples/node-api.faf         valid   TROPHY 100%  17/17 slots
examples/python-ml.faf        valid   TROPHY 100%  17/17 slots
examples/react-dashboard.faf  valid   TROPHY 100%  21/21 slots
examples/svelte-saas.faf      valid   TROPHY 100%  21/21 slots
```

(Slot count varies because `slotignored` slots aren't counted — a CLI with no frontend still hits Trophy.)

## README

Refreshed — accurate stack table, `faf sync` instead of the non-existent `faf bi-sync`, the current shape documented.

## Test plan

- [x] `faf check <each>` → valid
- [x] `faf score <each>` → TROPHY 100%
- [x] `bun test` → 1397 pass / 0 fail (examples aren't imported by any test)