### PR TITLE
faf-cli 7.13.1 — security: detection reads stay inside the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!-- faf: faf-cli | TypeScript | cli | CLI for the .faf format — IANA-registered AI context that versions with your code -->
-<!-- faf: doc=changelog | latest=v7.13.0 | canonical=project.faf | family=FAF -->
+<!-- faf: doc=changelog | latest=v7.13.1 | canonical=project.faf | family=FAF -->
 
 # Changelog
 
@@ -8,7 +8,14 @@ All notable changes to faf-cli will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.13.1] - 2026-09-12 — The Co-Author Edition
+
+**A security patch: faf-cli's detection no longer follows a link out of your project, so a hostile repo can't pull a file like `~/.aws/credentials` into project.faf or your AI's context.**
+
+### Security
+- Detection reads stay inside the project: a README.md, package.json, pyproject.toml or any other repo file that links outside the project, into `.git` or to nothing is treated as absent, so its text never reaches project.faf, CLAUDE.md, AGENTS.md or the output. A link inside the project still works, from the root (README.md → docs/README.md) and from a subfolder (web/package.json → ../shared/web-package.json).
+- `faf git` clones with `core.symlinks=false`, so a cloned repo's links are never followed. Each link then arrives as a plain file holding only the link's path; faf takes those placeholders out of its own temporary clone, so a path like `docs/README.md` is never read as the README or written into project.goal.
+- `faf cards` reads `agent.fafa` through the same safe path as every other faf file: an `agent.fafa` that links out of its folder is refused in one line, never read or quoted.
 
 ### Changed
 - **`slotignored` is shown as `slotignored`, never N/A.** A slot has three states: empty (the default), `slotignored` (from the app-type: not required, not scored) and populated. The `faf score` slot breakdown, the `faf show` statline and the typed-words line now say `slotignored`, replacing the N/A label. A typed `N/A` in a slot that needs a fact is still empty and scores 0.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,12 @@
 <!-- faf:start -->
-<!-- faf: faf-cli | TypeScript | cli | CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memory. TypeScript, Bun-native since v6. package faf-cli v7.13.0 The Co-Author Edition. -->
+<!-- faf: faf-cli | TypeScript | cli | CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memory. TypeScript, Bun-native since v6. package faf-cli v7.13.1 The Co-Author Edition. -->
 <!-- faf: claim=project.faf | family=FAF -->
 
 # CLAUDE.md — faf-cli
 
 ## What This Is
 
-CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memory. TypeScript, Bun-native since v6. package faf-cli v7.13.0 The Co-Author Edition.
+CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memory. TypeScript, Bun-native since v6. package faf-cli v7.13.1 The Co-Author Edition.
 
 ## Stack
 
@@ -18,10 +18,10 @@ CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memo
 - **What:** Persistent AI Context Standard — project DNA for AI. IANA-registered. Anthropic-merged.
 - **Why:** Eliminates 91% context re-discovery tax — define once, AI remembers forever
 - **Where:** npm registry, Homebrew, GitHub
-- **When:** Production since September 2025; Bun-native since v6; current package 7.13.0
+- **When:** Production since September 2025; Bun-native since v6; current package 7.13.1
 - **How:** bunx faf-cli auto, then project.faf versions with your code — faf show renders it human-visible
 
 ---
 
-*STATUS: SYNC ACTIVE — 2026-09-12T07:14:06.804Z*
+*STATUS: SYNC ACTIVE — 2026-09-13T03:00:16.820Z*
 <!-- faf:end -->

--- a/README.md
+++ b/README.md
@@ -132,7 +132,16 @@ faf memory etch "a durable fact" --id my-fact
 faf memory show
 ```
 
-### What's New in v7.13.0 — The Co-Author Edition
+### What's New in v7.13.1 — The Co-Author Edition
+
+**A security patch: faf-cli's detection no longer follows a link out of your project, so a hostile repo can't pull a file like `~/.aws/credentials` into project.faf or your AI's context.**
+
+- **Detection reads stay inside the project.** A README.md, package.json or any other repo file that links outside the project is treated as absent. Links inside the project still work.
+- **`faf git` clones with symlinks off**, and never reads a link's path as a file's content.
+- **`faf cards` reads `agent.fafa` safely**: a link out of its folder is refused.
+- **`slotignored` is shown as `slotignored`**, never N/A.
+
+#### v7.13.0 — the Edition release
 
 **You and your AI co-author project.faf — AI fills the tech facts from your repo, you write the 6Ws — and faf-cli only touches what it wrote: links can't lead it outside your project, a failed write keeps the original, and your comments, values and notes stay as you left them.**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faf-cli",
-  "version": "7.13.0",
+  "version": "7.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faf-cli",
-      "version": "7.13.0",
+      "version": "7.13.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "faf-cli",
-  "version": "7.13.0",
+  "version": "7.13.1",
   "description": "Persistent AI context + memory — .faf and .fafm, IANA-registered. Anthropic-merged.",
   "type": "module",
   "icon": "https://faf.one/orange-smiley.svg",

--- a/project.faf
+++ b/project.faf
@@ -1,8 +1,8 @@
 faf_version: "3.0"
 project:
   name: faf-cli
-  version: "7.13.0"
-  goal: "CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memory. TypeScript, Bun-native since v6. package faf-cli v7.13.0 The Co-Author Edition."
+  version: "7.13.1"
+  goal: "CLI for IANA-registered `.faf` + `.fafm` — context DNA and portable agent memory. TypeScript, Bun-native since v6. package faf-cli v7.13.1 The Co-Author Edition."
   main_language: TypeScript
   type: cli  # found: package.json bin
 # Commands + key_files feed `faf export --agents` (hand values win over detection).
@@ -58,7 +58,7 @@ human_context:
   what: Persistent AI Context Standard — project DNA for AI. IANA-registered. Anthropic-merged.
   why: Eliminates 91% context re-discovery tax — define once, AI remembers forever
   where: npm registry, Homebrew, GitHub
-  when: Production since September 2025; Bun-native since v6; current package 7.13.0
+  when: Production since September 2025; Bun-native since v6; current package 7.13.1
   how: bunx faf-cli auto, then project.faf versions with your code — faf show renders it human-visible
 monorepo:
   packages_count: slotignored

--- a/src/commands/git.ts
+++ b/src/commands/git.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs';
 import { join, resolve } from 'path';
 import { execFileSync } from 'child_process';
-import { makeTempDir, removeTempDir } from '../core/safe-write.js';
+import { makeTempDir, readBytesIfPresent, removeTempDir, safeUnlink } from '../core/safe-write.js';
 import { refuseMissingOutputFolder } from '../core/refusal.js';
 import { authorFafFromRepo, normalizeGitUrl, repoNameFromUrl } from '../detect/git-repo.js';
 import { writeFaf, readFafRaw, serializeFaf, withKernel } from '../interop/faf.js';
@@ -26,11 +26,45 @@ export interface GitCommandOptions {
   stdout?: boolean;
 }
 
+/**
+ * With core.symlinks=false, every path git records as a link (mode 120000)
+ * arrives in the clone as a plain file holding the link's target text. That
+ * text is not the file: detection would read `docs/README.md` as the README
+ * and write it into project.goal. The placeholders are taken out of faf's own
+ * throwaway clone, so detection sees them as absent, as it sees any link.
+ * Returns how many were taken out.
+ */
+export function dropLinkPlaceholders(cloneDir: string): number {
+  let listing: string;
+  try {
+    listing = execFileSync('git', ['-C', cloneDir, 'ls-files', '-s', '-z'], { stdio: ['ignore', 'pipe', 'pipe'] }).toString();
+  } catch {
+    return 0;
+  }
+  let dropped = 0;
+  for (const rec of listing.split('\0')) {
+    if (!rec.startsWith('120000 ')) {continue;}
+    const tab = rec.indexOf('\t');
+    if (tab < 0) {continue;}
+    const full = join(cloneDir, rec.slice(tab + 1));
+    const bytes = readBytesIfPresent(full);
+    if (bytes === null) {continue;}
+    try {
+      if (safeUnlink(full, { root: cloneDir, expect: bytes })) {dropped++;}
+    } catch {
+      // Not a plain placeholder (a folder or something unexpected): leave it.
+    }
+  }
+  return dropped;
+}
+
 /** The `git clone` argv — split out so the --ref plumbing is testable without a network. */
 export function cloneArgs(repoUrl: string, tmpDir: string, ref?: string): string[] {
-  // --depth 1 keeps it instant; --branch pins a branch or tag for versioned context.
-  // `--` stops the URL ever being read as a flag.
-  return ['clone', '--depth', '1', ...(ref ? ['--branch', ref] : []), '--', repoUrl, tmpDir];
+  // core.symlinks=false: a link in the repo arrives as a plain file holding the
+  // link's text, so a README.md that links to ~/.aws/credentials is never
+  // followed. --depth 1 keeps it instant; --branch pins a branch or tag for
+  // versioned context. `--` stops the URL ever being read as a flag.
+  return ['clone', '-c', 'core.symlinks=false', '--depth', '1', ...(ref ? ['--branch', ref] : []), '--', repoUrl, tmpDir];
 }
 
 /**
@@ -103,6 +137,7 @@ export function gitCommand(
     // Full slot-filling pipeline (shared with `faf auto`) — not detectStack alone —
     // named after the REPO, not the throwaway clone dir (a real package.json name
     // is kept). The same function consumers call on a repo they fetched.
+    dropLinkPlaceholders(cloneDir);
     const data = authorFafFromRepo(cloneDir, { repoUrl });
 
     if (target.outputPath === null) {

--- a/src/commands/taf.ts
+++ b/src/commands/taf.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { findFafFile, readFaf, readFafRaw, withKernel } from '../interop/faf.js';
 import { scoreFafYaml } from '../core/scorer.js';
-import { makeDirInside, safeWriteFile } from '../core/safe-write.js';
+import { makeDirInside, repoExists, safeWriteFile } from '../core/safe-write.js';
 import { writeRendered } from '../core/render-hash.js';
 import { refuseMissingOutputFolder } from '../core/refusal.js';
 import { fafCyan, dim, bold } from '../ui/colors.js';
@@ -55,9 +55,9 @@ export function tafCommand(subcommand?: string | TafOptions, options: TafOptions
 type Runner = 'bun' | 'pnpm' | 'yarn' | 'npm';
 
 function detectRunner(dir: string): Runner {
-  if (existsSync(join(dir, 'bun.lockb')) || existsSync(join(dir, 'bun.lock'))) {return 'bun';}
-  if (existsSync(join(dir, 'pnpm-lock.yaml'))) {return 'pnpm';}
-  if (existsSync(join(dir, 'yarn.lock'))) {return 'yarn';}
+  if (repoExists(dir, 'bun.lockb') || repoExists(dir, 'bun.lock')) {return 'bun';}
+  if (repoExists(dir, 'pnpm-lock.yaml')) {return 'pnpm';}
+  if (repoExists(dir, 'yarn.lock')) {return 'yarn';}
   return 'npm';
 }
 
@@ -94,7 +94,7 @@ function buildTafWorkflow(dir: string): string {
     '      - uses: actions/checkout@v4\n';
 
   let body: string;
-  if (existsSync(join(dir, 'package.json'))) {
+  if (repoExists(dir, 'package.json')) {
     const r = RUNTIME[detectRunner(dir)];
     body =
       `${r.setup}\n` +

--- a/src/core/safe-write.ts
+++ b/src/core/safe-write.ts
@@ -46,11 +46,20 @@
  * byte for byte what faf last wrote (their render hash, render-hash.ts); a
  * `.fafb` must carry the FAFB header (see {@link safeReplaceOwned}). Anything
  * else is refused unless the caller passes `force` (the CLI's `--force`).
+ *
+ * Rule 6 — detection reads stay inside the project. The files faf reads to fill
+ * slots and render context (README.md, package.json, pyproject.toml,
+ * Cargo.toml, go.mod, …) go through {@link repoFile}: resolved on disk, every
+ * link followed. A file whose real path, or the folder it sits in, leaves the
+ * project folder, runs through `.git`, or is a dangling link is absent to
+ * detection: it does not exist, and reading it gives nothing. A link that
+ * stays inside the project is followed (README.md → docs/README.md).
  */
 import {
   accessSync,
   closeSync,
   constants,
+  existsSync,
   fchmodSync,
   fchownSync,
   fsyncSync,
@@ -67,6 +76,8 @@ import {
   statSync,
   unlinkSync,
   writeFileSync,
+  type Dirent,
+  type Stats,
 } from 'fs';
 import { randomBytes } from 'crypto';
 import { tmpdir } from 'os';
@@ -398,6 +409,110 @@ export function readBytesIfPresent(path: string): Buffer | null {
     if (errnoOf(e) === 'ENOENT') {return null;}
     throw e;
   }
+}
+
+/**
+ * Where detection may read `rel` in the project folder `dir` — its real path —
+ * or null when detection treats it as absent (Rule 6). `rel` names a file or a
+ * folder, relative to `dir` (as `join(dir, rel)`). Every link on the way is
+ * followed, the folders included; the result is null when:
+ *   - nothing is there, or a link on the way dangles or loops
+ *   - the real path leaves `dir` (README.md → ~/.aws/credentials, or a folder
+ *     on the way that is a link out)
+ *   - the real path runs through `.git` (README.md → .git/config)
+ * A link that stays inside `dir` is followed. `dir` is the folder detection
+ * was handed: the project, or a folder below it that detection reads on its
+ * own (a subfolder's manifest), so a link may not leave that folder either.
+ */
+export function repoFile(dir: string, rel: string): string | null {
+  const full = resolve(join(dir, rel));
+  if (!existsSync(full)) {return null;} // not there, or a dangling link
+  let root: string;
+  let real: string;
+  try {
+    root = realpath(detectionBoundary(dir));
+    real = realpath(full);
+  } catch {
+    return null; // a loop, or gone meanwhile
+  }
+  if (!isInside(root, real) || inGitDir(relative(root, real))) {return null;}
+  return real;
+}
+
+/** The project folders detection is running in, outermost first (see
+ *  {@link withRepoRoot}). */
+const detectionRoots: string[] = [];
+
+/** The folder a read in `dir` may not leave: the outermost project folder
+ *  detection is running in that holds `dir`, or `dir` itself. */
+function detectionBoundary(dir: string): string {
+  const base = resolve(dir);
+  return detectionRoots.find(r => base === r || base.startsWith(r.endsWith(sep) ? r : r + sep)) ?? base;
+}
+
+/**
+ * Run `scan` with `root` as the project folder for every detection read under
+ * it: a read in a subfolder (web/package.json) may then follow a link to
+ * anywhere inside `root` (../shared/web-package.json), not only inside that
+ * subfolder. A link out of `root` is still absent. Subfolder scans use this.
+ */
+export function withRepoRoot<T>(root: string, scan: () => T): T {
+  detectionRoots.push(resolve(root));
+  try {
+    return scan();
+  } finally {
+    detectionRoots.pop();
+  }
+}
+
+/** True when `rel` (a file or a folder) is in the project folder `dir` for
+ *  detection: see {@link repoFile}. */
+export function repoExists(dir: string, rel: string): boolean {
+  return repoFile(dir, rel) !== null;
+}
+
+/** The text of the file `rel` in the project folder `dir` (UTF-8, read the way
+ *  detection reads it), or null when detection treats it as absent (see
+ *  {@link repoFile}), it is not a regular file, or it cannot be read. */
+export function readRepoFile(dir: string, rel: string): string | null {
+  const real = repoFile(dir, rel);
+  if (real === null) {return null;}
+  try {
+    return statSync(real).isFile() ? readFileSync(real, 'utf-8') : null;
+  } catch {
+    return null;
+  }
+}
+
+/** What `rel` is (its real path's stats) in the project folder `dir`, or null
+ *  when detection treats it as absent (see {@link repoFile}). */
+export function statRepoFile(dir: string, rel: string): Stats | null {
+  const real = repoFile(dir, rel);
+  if (real === null) {return null;}
+  try {
+    return statSync(real);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The entries of the folder `rel` (default: `dir` itself) in the project
+ * folder `dir`, or null when detection treats the folder as absent (see
+ * {@link repoFile}) or it cannot be read. A link among them that leaves `dir`,
+ * dangles, or leads into `.git` is left out: detection does not see it. Each
+ * entry says what it is itself (a link is a link, as readdirSync gives it).
+ */
+export function readRepoDir(dir: string, rel = '.'): Dirent[] | null {
+  const real = repoFile(dir, rel);
+  if (real === null) {return null;}
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(real, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  return entries.filter(e => !e.isSymbolicLink() || repoFile(dir, join(rel, e.name)) !== null);
 }
 
 /** What to keep from the file already at `target` — its permission bits and

--- a/src/detect/csharp.ts
+++ b/src/detect/csharp.ts
@@ -1,5 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from 'fs';
-import { join } from 'path';
+import { readRepoDir, readRepoFile } from '../core/safe-write.js';
 import spec from './csharp-detection.json';
 
 /**
@@ -260,12 +259,7 @@ export function classifyCsproj(
 
 /** List root-level .csproj filenames in a directory. */
 export function listRootCsprojs(dir: string): string[] {
-  if (!existsSync(dir)) {return [];}
-  try {
-    return readdirSync(dir).filter(f => f.toLowerCase().endsWith('.csproj')).sort();
-  } catch {
-    return [];
-  }
+  return (readRepoDir(dir) ?? []).map(e => e.name).filter(f => f.toLowerCase().endsWith('.csproj')).sort();
 }
 
 /**
@@ -281,13 +275,8 @@ export function detectCsharpProject(dir: string): CsharpProject | null {
   let bestRank = 999;
 
   for (const file of files) {
-    const path = join(dir, file);
-    let content: string;
-    try {
-      content = readFileSync(path, 'utf-8');
-    } catch {
-      continue;
-    }
+    const content = readRepoFile(dir, file);
+    if (content === null) {continue;}
     const parsed = parseCsproj(content);
     const classified = classifyCsproj(parsed, file);
     const r = rank(classified.appType, classified.framework);

--- a/src/detect/dart.ts
+++ b/src/detect/dart.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
+import { readRepoDir, readRepoFile, repoExists } from '../core/safe-write.js';
 import spec from './dart-detection.json';
 
 /**
@@ -62,14 +62,8 @@ function pubspecDeps(content: string): Set<string> {
 
 /** Classify a Dart/Flutter project from its pubspec.yaml. Returns null if not Dart. */
 export function detectDartProject(dir: string): DartProject | null {
-  const path = join(dir, 'pubspec.yaml');
-  if (!existsSync(path)) {return null;}
-  let content: string;
-  try {
-    content = readFileSync(path, 'utf-8');
-  } catch {
-    return null;
-  }
+  const content = readRepoFile(dir, 'pubspec.yaml');
+  if (content === null) {return null;}
 
   const deps = pubspecDeps(content);
   const has = (d: string) => deps.has(d.toLowerCase());
@@ -87,10 +81,7 @@ export function detectDartProject(dir: string): DartProject | null {
 
   // CLI: a top-level `executables:` section, or bin/*.dart entry points.
   const hasExecutables = /^executables:\s*$/m.test(content);
-  let hasBinDart = false;
-  try {
-    hasBinDart = readdirSync(join(dir, 'bin')).some(f => f.endsWith('.dart'));
-  } catch { /* no bin/ */ }
+  const hasBinDart = (readRepoDir(dir, 'bin') ?? []).some(e => e.name.endsWith('.dart'));
   const isCli = hasExecutables || hasBinDart;
 
   let appType: DartAppType;
@@ -101,7 +92,7 @@ export function detectDartProject(dir: string): DartProject | null {
     framework = 'Flutter';
     // App vs package: an app has lib/main.dart (the entry) or `publish_to: none`;
     // a reusable Flutter package has neither — it's publishable, lib/ exports only.
-    const isApp = existsSync(join(dir, 'lib', 'main.dart')) || /^publish_to:\s*['"]?none\b/m.test(content);
+    const isApp = repoExists(dir, join('lib', 'main.dart')) || /^publish_to:\s*['"]?none\b/m.test(content);
     if (isApp) {
       appType = 'mobile';
       found = 'pubspec.yaml (Flutter app)';

--- a/src/detect/enrich.ts
+++ b/src/detect/enrich.ts
@@ -1,6 +1,5 @@
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
 import type { FafData } from '../core/types.js';
+import { readRepoFile, repoExists } from '../core/safe-write.js';
 import { detectCommands, detectKeyFiles } from './scanner.js';
 
 type Pkg = {
@@ -16,14 +15,8 @@ type Pkg = {
  */
 function detectConventions(dir: string, pkg: Pkg): string[] {
   const conv: string[] = [];
-  const has = (f: string): boolean => existsSync(join(dir, f));
-  const read = (f: string): string => {
-    try {
-      return readFileSync(join(dir, f), 'utf-8');
-    } catch {
-      return '';
-    }
-  };
+  const has = (f: string): boolean => repoExists(dir, f);
+  const read = (f: string): string => readRepoFile(dir, f) ?? '';
 
   if (has('tsconfig.json') && /"strict"\s*:\s*true/.test(read('tsconfig.json'))) {
     conv.push('TypeScript strict mode (tsconfig.json)');
@@ -64,10 +57,10 @@ export function enrichFromRepo(dir: string, data: FafData): FafData {
   const out: FafData = { ...data };
 
   let pkg: unknown = null;
-  const pj = join(dir, 'package.json');
-  if (existsSync(pj)) {
+  const pj = readRepoFile(dir, 'package.json');
+  if (pj !== null) {
     try {
-      pkg = JSON.parse(readFileSync(pj, 'utf-8'));
+      pkg = JSON.parse(pj);
     } catch {
       pkg = null;
     }
@@ -90,10 +83,10 @@ export function enrichFromRepo(dir: string, data: FafData): FafData {
   // Security: detect a secrets file (.env), keep hand-authored if present.
   if (!data.security) {
     const envFiles = ['.env', '.env.local', '.env.development'];
-    const secrets = envFiles.find((f) => existsSync(join(dir, f)));
+    const secrets = envFiles.find((f) => repoExists(dir, f));
     if (secrets) {
       const example = ['.env.example', '.env.sample', '.env.template'].find((f) =>
-        existsSync(join(dir, f)),
+        repoExists(dir, f),
       );
       out.security = { secrets, ...(example ? { example } : {}) };
     }

--- a/src/detect/go.ts
+++ b/src/detect/go.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
+import { readRepoDir, readRepoFile, statRepoFile } from '../core/safe-write.js';
 import spec from './go-detection.json';
 
 /**
@@ -98,46 +98,28 @@ function extractModulePath(content: string): string {
 
 /** Layout signal: cmd/ with Go files → common CLI / multi-main layout. */
 function hasCmdDir(dir: string): boolean {
-  const cmd = join(dir, 'cmd');
-  if (!existsSync(cmd)) {return false;}
-  try {
-    for (const name of readdirSync(cmd)) {
-      const p = join(cmd, name);
-      try {
-        if (statSync(p).isDirectory()) {
-          const files = readdirSync(p);
-          if (files.some(f => f.endsWith('.go'))) {return true;}
-        } else if (name.endsWith('.go')) {
-          return true;
-        }
-      } catch { /* skip */ }
+  for (const { name } of readRepoDir(dir, 'cmd') ?? []) {
+    const p = join('cmd', name);
+    const st = statRepoFile(dir, p);
+    if (st?.isDirectory()) {
+      if ((readRepoDir(dir, p) ?? []).some(e => e.name.endsWith('.go'))) {return true;}
+    } else if (st && name.endsWith('.go')) {
+      return true;
     }
-  } catch { /* no cmd */ }
+  }
   return false;
 }
 
 /** Root main.go that declares package main. */
 function hasRootMainPackage(dir: string): boolean {
-  const p = join(dir, 'main.go');
-  if (!existsSync(p)) {return false;}
-  try {
-    const body = readFileSync(p, 'utf-8');
-    return /^package\s+main\b/m.test(body);
-  } catch {
-    return false;
-  }
+  const body = readRepoFile(dir, 'main.go');
+  return body !== null && /^package\s+main\b/m.test(body);
 }
 
 /** Classify a Go project from go.mod (+ light layout). Returns null if not Go. */
 export function detectGoProject(dir: string): GoProject | null {
-  const path = join(dir, 'go.mod');
-  if (!existsSync(path)) {return null;}
-  let content: string;
-  try {
-    content = readFileSync(path, 'utf-8');
-  } catch {
-    return null;
-  }
+  const content = readRepoFile(dir, 'go.mod');
+  if (content === null) {return null;}
 
   const modulePath = extractModulePath(content);
   const reqs = goModRequires(content);

--- a/src/detect/jvm.ts
+++ b/src/detect/jvm.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
+import { readRepoDir, readRepoFile, repoExists, statRepoFile } from '../core/safe-write.js';
 import spec from './jvm-detection.json';
 
 /**
@@ -79,15 +79,7 @@ const JVM_ROOT_MARKERS = [
 
 /** True if directory looks like a JVM project root (or multi-module root). */
 export function isJvmRoot(dir: string): boolean {
-  return JVM_ROOT_MARKERS.some(f => existsSync(join(dir, f)));
-}
-
-function readText(path: string): string | null {
-  try {
-    return readFileSync(path, 'utf-8');
-  } catch {
-    return null;
-  }
+  return JVM_ROOT_MARKERS.some(f => repoExists(dir, f));
 }
 
 /** Minimal TOML-ish parse for gradle/libs.versions.toml plugins + libraries. */
@@ -153,9 +145,7 @@ export function parseVersionCatalog(content: string): Catalog {
 }
 
 function loadCatalog(root: string): Catalog {
-  const path = join(root, 'gradle', 'libs.versions.toml');
-  if (!existsSync(path)) {return { plugins: new Map(), libraries: new Map() };}
-  const body = readText(path);
+  const body = readRepoFile(root, join('gradle', 'libs.versions.toml'));
   if (!body) {return { plugins: new Map(), libraries: new Map() };}
   return parseVersionCatalog(body);
 }
@@ -337,33 +327,29 @@ function hasMcp(artifacts: Set<string>): string | undefined {
   return best;
 }
 
-function probeSources(dir: string): { kotlin: boolean; java: boolean; hints: Set<string> } {
+/** Source hints under the module folder `rel` of the project folder `root`. */
+function probeSources(root: string, rel: string): { kotlin: boolean; java: boolean; hints: Set<string> } {
   const hints = new Set<string>();
   let kotlin = false;
   let java = false;
   const roots = [
-    join(dir, 'src'),
-    join(dir, 'src', 'main'),
+    join(rel, 'src'),
+    join(rel, 'src', 'main'),
   ];
   const walk = (p: string, depth: number): void => {
-    if (depth > 4 || !existsSync(p)) {return;}
-    let entries: string[];
-    try {
-      entries = readdirSync(p);
-    } catch {
-      return;
-    }
-    for (const name of entries) {
+    if (depth > 4) {return;}
+    const entries = readRepoDir(root, p);
+    if (!entries) {return;}
+    for (const { name } of entries) {
       if (name === 'androidMain' || name === 'commonMain' || name === 'jvmMain' || name === 'iosMain') {
         hints.add(name);
       }
       const full = join(p, name);
-      try {
-        const st = statSync(full);
-        if (st.isDirectory()) {walk(full, depth + 1);}
-        else if (name.endsWith('.kt') || name.endsWith('.kts')) {kotlin = true;}
-        else if (name.endsWith('.java')) {java = true;}
-      } catch { /* skip */ }
+      const st = statRepoFile(root, full);
+      if (!st) {continue;}
+      if (st.isDirectory()) {walk(full, depth + 1);}
+      else if (name.endsWith('.kt') || name.endsWith('.kts')) {kotlin = true;}
+      else if (name.endsWith('.java')) {java = true;}
     }
   };
   for (const r of roots) {walk(r, 0);}
@@ -475,16 +461,15 @@ function rank(appType: JvmAppType, facets: string[]): number {
 }
 
 function collectGradleModule(root: string, rel: string, catalog: Catalog): ModuleSignals | null {
-  const dir = rel ? join(root, rel) : root;
-  const kts = join(dir, 'build.gradle.kts');
-  const groovy = join(dir, 'build.gradle');
-  const path = existsSync(kts) ? kts : existsSync(groovy) ? groovy : null;
+  const kts = join(rel, 'build.gradle.kts');
+  const groovy = join(rel, 'build.gradle');
+  const path = repoExists(root, kts) ? kts : repoExists(root, groovy) ? groovy : null;
   if (!path) {return null;}
-  const content = readText(path);
+  const content = readRepoFile(root, path);
   if (!content) {return null;}
   const plugins = extractGradlePlugins(content, catalog);
   const artifacts = extractGradleArtifacts(content, catalog);
-  const sources = probeSources(dir);
+  const sources = probeSources(root, rel);
   const hasMainClass =
     /mainClass\s*[.=]/.test(content) ||
     /mainClassName\s*=/.test(content) ||
@@ -509,13 +494,10 @@ function collectGradleModule(root: string, rel: string, catalog: Catalog): Modul
 }
 
 function collectMavenModule(root: string, rel: string): ModuleSignals | null {
-  const dir = rel ? join(root, rel) : root;
-  const pomPath = join(dir, 'pom.xml');
-  if (!existsSync(pomPath)) {return null;}
-  const content = readText(pomPath);
+  const content = readRepoFile(root, join(rel, 'pom.xml'));
   if (!content) {return null;}
   const { packaging, parents, artifacts } = extractMavenSignals(content);
-  const sources = probeSources(dir);
+  const sources = probeSources(root, rel);
   return {
     path: rel ? `${rel}/pom.xml` : 'pom.xml',
     plugins: new Set(),
@@ -544,9 +526,8 @@ export function detectJvmProject(dir: string): JvmProject | null {
   // Gradle settings → includes
   let settingsBody: string | null = null;
   for (const s of ['settings.gradle.kts', 'settings.gradle']) {
-    const p = join(dir, s);
-    if (existsSync(p)) {
-      settingsBody = readText(p);
+    if (repoExists(dir, s)) {
+      settingsBody = readRepoFile(dir, s);
       break;
     }
   }
@@ -565,7 +546,7 @@ export function detectJvmProject(dir: string): JvmProject | null {
   const rootPom = collectMavenModule(dir, '');
   if (rootPom) {
     modules.push(rootPom);
-    const pomContent = readText(join(dir, 'pom.xml'));
+    const pomContent = readRepoFile(dir, 'pom.xml');
     if (pomContent) {
       const { modules: mavMods } = extractMavenSignals(pomContent);
       for (const mm of mavMods) {

--- a/src/detect/relentless.ts
+++ b/src/detect/relentless.ts
@@ -12,8 +12,7 @@
  * this rewrite corrects).
  */
 
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { readRepoFile } from '../core/safe-write.js';
 
 interface PkgJson {
   description?: string;
@@ -103,10 +102,10 @@ export function relentlessContext(dir: string, opts: RelentlessOpts = {}): Seede
 }
 
 function readPkg(dir: string): PkgJson | null {
-  const p = join(dir, 'package.json');
-  if (!existsSync(p)) {return null;}
+  const text = readRepoFile(dir, 'package.json');
+  if (text === null) {return null;}
   try {
-    return JSON.parse(readFileSync(p, 'utf-8')) as PkgJson;
+    return JSON.parse(text) as PkgJson;
   } catch {
     return null;
   }
@@ -114,14 +113,8 @@ function readPkg(dir: string): PkgJson | null {
 
 /** README with HTML tags + badge lines stripped (so we don't seed shields.io noise). */
 function cleanReadme(dir: string): string {
-  const p = join(dir, 'README.md');
-  if (!existsSync(p)) {return '';}
-  let txt: string;
-  try {
-    txt = readFileSync(p, 'utf-8');
-  } catch {
-    return '';
-  }
+  const txt = readRepoFile(dir, 'README.md');
+  if (txt === null) {return '';}
   return txt
     .replace(/<!--[\s\S]*?-->/g, '') // HTML comment blocks (asset notes, TODOs — not prose)
     .split('\n')

--- a/src/detect/ruby.ts
+++ b/src/detect/ruby.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
+import { readRepoDir, readRepoFile, repoExists, statRepoFile } from '../core/safe-write.js';
 import spec from './ruby-detection.json';
 
 /**
@@ -36,26 +36,14 @@ const RAILS_LAYOUT = spec.railsLayoutFiles as string[];
 /** True if directory looks like a Ruby project root. */
 export function isRubyRoot(dir: string): boolean {
   return (
-    existsSync(join(dir, 'Gemfile')) ||
-    existsSync(join(dir, 'gems.rb')) ||
+    repoExists(dir, 'Gemfile') ||
+    repoExists(dir, 'gems.rb') ||
     hasGemspec(dir)
   );
 }
 
 function hasGemspec(dir: string): boolean {
-  try {
-    return readdirSync(dir).some(f => f.endsWith('.gemspec'));
-  } catch {
-    return false;
-  }
-}
-
-function readText(path: string): string | null {
-  try {
-    return readFileSync(path, 'utf-8');
-  } catch {
-    return null;
-  }
+  return (readRepoDir(dir) ?? []).some(e => e.name.endsWith('.gemspec'));
 }
 
 /**
@@ -121,30 +109,27 @@ function collectGems(dir: string): { gems: Set<string>; sources: string[] } {
   const sources: string[] = [];
 
   for (const name of ['Gemfile', 'gems.rb']) {
-    const p = join(dir, name);
-    const body = readText(p);
+    const body = readRepoFile(dir, name);
     if (body) {
       for (const g of parseGemfileGems(body)) {gems.add(g);}
       sources.push(name);
     }
   }
 
-  const lock = readText(join(dir, 'Gemfile.lock')) || readText(join(dir, 'gems.locked'));
+  const lock = readRepoFile(dir, 'Gemfile.lock') || readRepoFile(dir, 'gems.locked');
   if (lock) {
     for (const g of parseGemfileLockGems(lock)) {gems.add(g);}
     sources.push('Gemfile.lock');
   }
 
-  try {
-    for (const f of readdirSync(dir)) {
-      if (!f.endsWith('.gemspec')) {continue;}
-      const body = readText(join(dir, f));
-      if (body) {
-        for (const g of parseGemspecGems(body)) {gems.add(g);}
-        sources.push(f);
-      }
+  for (const { name: f } of readRepoDir(dir) ?? []) {
+    if (!f.endsWith('.gemspec')) {continue;}
+    const body = readRepoFile(dir, f);
+    if (body) {
+      for (const g of parseGemspecGems(body)) {gems.add(g);}
+      sources.push(f);
     }
-  } catch { /* skip */ }
+  }
 
   return { gems, sources };
 }
@@ -179,7 +164,7 @@ function findMcp(gems: Set<string>): string | undefined {
 
 function railsLayoutHit(dir: string): string | undefined {
   for (const rel of RAILS_LAYOUT) {
-    if (existsSync(join(dir, rel))) {return rel;}
+    if (repoExists(dir, rel)) {return rel;}
   }
   return undefined;
 }
@@ -189,33 +174,25 @@ function hasCliShape(dir: string, gems: Set<string>): { hit: boolean; why: strin
   const cli = findLabeled(gems, CLI_GEMS);
   if (cli) {return { hit: true, why: cli[0] };}
 
-  try {
-    for (const f of readdirSync(dir)) {
-      if (!f.endsWith('.gemspec')) {continue;}
-      const body = readText(join(dir, f));
-      if (body && /executables\s*=/.test(body) && !/executables\s*=\s*\[\s*\]/.test(body)) {
-        return { hit: true, why: `${f} executables` };
-      }
+  for (const { name: f } of readRepoDir(dir) ?? []) {
+    if (!f.endsWith('.gemspec')) {continue;}
+    const body = readRepoFile(dir, f);
+    if (body && /executables\s*=/.test(body) && !/executables\s*=\s*\[\s*\]/.test(body)) {
+      return { hit: true, why: `${f} executables` };
     }
-  } catch { /* skip */ }
+  }
 
-  const binDir = join(dir, 'bin');
-  if (existsSync(binDir)) {
-    try {
-      const bins = readdirSync(binDir).filter(b => {
-        if (b === 'setup' || b === 'console' || b === 'rake') {return false;}
-        try {
-          return statSync(join(binDir, b)).isFile();
-        } catch {
-          return false;
-        }
-      });
-      // bin/rails alone is Rails, not CLI product
-      const nonRails = bins.filter(b => b !== 'rails');
-      if (nonRails.length > 0 && !hasGem(gems, 'rails') && !railsLayoutHit(dir)) {
-        return { hit: true, why: `bin/${nonRails[0]}` };
-      }
-    } catch { /* skip */ }
+  const binEntries = readRepoDir(dir, 'bin');
+  if (binEntries) {
+    const bins = binEntries.map(e => e.name).filter(b => {
+      if (b === 'setup' || b === 'console' || b === 'rake') {return false;}
+      return statRepoFile(dir, join('bin', b))?.isFile() === true;
+    });
+    // bin/rails alone is Rails, not CLI product
+    const nonRails = bins.filter(b => b !== 'rails');
+    if (nonRails.length > 0 && !hasGem(gems, 'rails') && !railsLayoutHit(dir)) {
+      return { hit: true, why: `bin/${nonRails[0]}` };
+    }
   }
 
   return { hit: false, why: '' };
@@ -240,7 +217,7 @@ export function detectRubyProject(dir: string): RubyProject | null {
   const railsLayout = railsLayoutHit(dir);
   const hasRailsGem = hasGem(gems, 'rails') || hasGem(gems, 'railties');
   const cliShape = hasCliShape(dir, gems);
-  const hasConfigRu = existsSync(join(dir, 'config.ru'));
+  const hasConfigRu = repoExists(dir, 'config.ru');
 
   // Rails is NEVER inferred from Gemfile existence alone.
   // rails gem and/or classic layout required.

--- a/src/detect/scanner.ts
+++ b/src/detect/scanner.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, readdirSync, type Dirent } from 'fs';
 import { join } from 'path';
+import { readRepoDir, readRepoFile, repoExists, withRepoRoot } from '../core/safe-write.js';
 import type { DetectedFramework, Signal } from '../core/types.js';
 import { NO_CLASSIFYING_SIGNALS } from '../core/slots.js';
 import { FRAMEWORKS } from './frameworks.js';
@@ -30,27 +30,16 @@ interface PackageJson {
 
 /** Read [package].name field from Cargo.toml — naive but adequate. */
 function readCargoName(dir: string): string | null {
-  const path = join(dir, 'Cargo.toml');
-  if (!existsSync(path)) {return null;}
-  try {
-    const content = readFileSync(path, 'utf-8');
-    const m = content.match(/^\s*\[package\][\s\S]*?^\s*name\s*=\s*"([^"]+)"/m);
-    return m ? m[1] : null;
-  } catch {
-    return null;
-  }
+  const content = readRepoFile(dir, 'Cargo.toml');
+  if (content === null) {return null;}
+  const m = content.match(/^\s*\[package\][\s\S]*?^\s*name\s*=\s*"([^"]+)"/m);
+  return m ? m[1] : null;
 }
 
 /** True if Cargo.toml declares one or more `[[bin]]` sections — Rust cli marker. */
 function hasCargoBin(dir: string): boolean {
-  const path = join(dir, 'Cargo.toml');
-  if (!existsSync(path)) {return false;}
-  try {
-    const content = readFileSync(path, 'utf-8');
-    return /^\s*\[\[bin\]\]/m.test(content);
-  } catch {
-    return false;
-  }
+  const content = readRepoFile(dir, 'Cargo.toml');
+  return content !== null && /^\s*\[\[bin\]\]/m.test(content);
 }
 
 /** Detect SDK signals — keyword-based per the SDK-priority doctrine.
@@ -86,10 +75,10 @@ function detectExtensionSignal(dir: string): string | null {
     'dist/manifest.json',
   ];
   for (const rel of candidates) {
-    const path = join(dir, rel);
-    if (!existsSync(path)) {continue;}
+    const text = readRepoFile(dir, rel);
+    if (text === null) {continue;}
     try {
-      const parsed = JSON.parse(readFileSync(path, 'utf-8')) as { manifest_version?: unknown };
+      const parsed = JSON.parse(text) as { manifest_version?: unknown };
       if (typeof parsed.manifest_version === 'number') {
         return `${rel} manifest_version ${parsed.manifest_version} (browser extension)`;
       }
@@ -101,21 +90,15 @@ function detectExtensionSignal(dir: string): string | null {
 /** Python data-science dependency detection (pyproject.toml + requirements.txt). */
 function detectDataScienceSignal(dir: string): string | null {
   const dsPatterns = /(numpy|pandas|jupyter|scikit-learn|sklearn|pytorch|tensorflow|matplotlib|scipy)/i;
-  const pyproject = join(dir, 'pyproject.toml');
-  if (existsSync(pyproject)) {
-    try {
-      const content = readFileSync(pyproject, 'utf-8');
-      const match = content.match(dsPatterns);
-      if (match) {return `pyproject.toml depends on ${match[1]}`;}
-    } catch { /* fall through */ }
+  const pyproject = readRepoFile(dir, 'pyproject.toml');
+  if (pyproject !== null) {
+    const match = pyproject.match(dsPatterns);
+    if (match) {return `pyproject.toml depends on ${match[1]}`;}
   }
-  const reqs = join(dir, 'requirements.txt');
-  if (existsSync(reqs)) {
-    try {
-      const content = readFileSync(reqs, 'utf-8');
-      const match = content.match(dsPatterns);
-      if (match) {return `requirements.txt contains ${match[1]}`;}
-    } catch { /* fall through */ }
+  const reqs = readRepoFile(dir, 'requirements.txt');
+  if (reqs !== null) {
+    const match = reqs.match(dsPatterns);
+    if (match) {return `requirements.txt contains ${match[1]}`;}
   }
   return null;
 }
@@ -131,7 +114,7 @@ function detectMobileSignal(dir: string, pkg: PackageJson | null): string | null
       }
     }
   }
-  if (existsSync(join(dir, 'ios')) && existsSync(join(dir, 'android'))) {
+  if (repoExists(dir, 'ios') && repoExists(dir, 'android')) {
     return 'ios/ + android/ dirs';
   }
   return null;
@@ -139,29 +122,21 @@ function detectMobileSignal(dir: string, pkg: PackageJson | null): string | null
 
 /** WASM target detection (Cargo cdylib + wasm32 OR build.zig wasm OR pkg WASM build scripts). */
 function detectWasmSignal(dir: string, pkg: PackageJson | null): string | null {
-  const cargoPath = join(dir, 'Cargo.toml');
-  if (existsSync(cargoPath)) {
-    try {
-      const content = readFileSync(cargoPath, 'utf-8');
-      // crate-type = ["cdylib"] is the canonical wasm-output marker
-      if (/crate-type\s*=\s*\[[^\]]*"cdylib"/.test(content)) {
-        return 'Cargo.toml crate-type = ["cdylib"]';
-      }
-      // wasm-bindgen / wasm-pack as deps
-      if (/wasm-bindgen|wasm-pack/i.test(content)) {
-        return 'Cargo.toml wasm-bindgen/wasm-pack';
-      }
-    } catch { /* fall through */ }
+  const cargo = readRepoFile(dir, 'Cargo.toml');
+  if (cargo !== null) {
+    // crate-type = ["cdylib"] is the canonical wasm-output marker
+    if (/crate-type\s*=\s*\[[^\]]*"cdylib"/.test(cargo)) {
+      return 'Cargo.toml crate-type = ["cdylib"]';
+    }
+    // wasm-bindgen / wasm-pack as deps
+    if (/wasm-bindgen|wasm-pack/i.test(cargo)) {
+      return 'Cargo.toml wasm-bindgen/wasm-pack';
+    }
   }
   // Zig WASM target — build.zig with .wasm or wasm in script
-  const buildZig = join(dir, 'build.zig');
-  if (existsSync(buildZig)) {
-    try {
-      const content = readFileSync(buildZig, 'utf-8');
-      if (/\.wasm\b|wasm32|setOutputFormat\(\.wasm/i.test(content)) {
-        return 'build.zig wasm target';
-      }
-    } catch { /* fall through */ }
+  const buildZig = readRepoFile(dir, 'build.zig');
+  if (buildZig !== null && /\.wasm\b|wasm32|setOutputFormat\(\.wasm/i.test(buildZig)) {
+    return 'build.zig wasm target';
   }
   // pkg keywords contains 'wasm' AND no app frameworks
   if (pkg?.keywords?.some(k => /^wasm(?:-|$)|webassembly/i.test(k))) {
@@ -173,7 +148,7 @@ function detectWasmSignal(dir: string, pkg: PackageJson | null): string | null {
 /** Bare HTML / vanilla site detection. */
 function detectHtmlSignal(dir: string, pkg: PackageJson | null): string | null {
   // Must have index.html at root
-  if (!existsSync(join(dir, 'index.html'))) {return null;}
+  if (!repoExists(dir, 'index.html')) {return null;}
   // Must NOT have any frontend deps (those would classify as frontend/website/etc)
   if (pkg?.dependencies || pkg?.devDependencies) {
     const allDeps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
@@ -262,7 +237,7 @@ function detectMcpaasSignal(dir: string, pkg: PackageJson | null, frameworks: De
 /** Monorepo-root — private workspace with multiple packages, no single dominant FW. */
 function detectMonorepoRootSignal(dir: string, pkg: PackageJson | null): string | null {
   if (!pkg?.private) {return null;}
-  const hasWorkspaces = !!pkg.workspaces || existsSync(join(dir, 'pnpm-workspace.yaml'));
+  const hasWorkspaces = !!pkg.workspaces || repoExists(dir, 'pnpm-workspace.yaml');
   if (!hasWorkspaces) {return null;}
   return 'private workspace + multi-package';
 }
@@ -299,13 +274,13 @@ const STACK_FW_CATEGORIES = new Set(['frontend', 'backend', 'database', 'css', '
 /** A directory carries a real language manifest (not just tooling/config). */
 function hasLanguageManifest(d: string): boolean {
   if (
-    existsSync(join(d, 'pyproject.toml')) || existsSync(join(d, 'manage.py')) ||
-    existsSync(join(d, 'setup.py')) || fileExists(d, 'requirements*.txt')
+    repoExists(d, 'pyproject.toml') || repoExists(d, 'manage.py') ||
+    repoExists(d, 'setup.py') || fileExists(d, 'requirements*.txt')
   ) {return true;}
-  if (existsSync(join(d, 'go.mod'))) {return true;}
-  if (existsSync(join(d, 'Cargo.toml'))) {return true;}
-  if (existsSync(join(d, 'Gemfile'))) {return true;}
-  if (existsSync(join(d, 'pom.xml')) || fileExists(d, 'build.gradle*')) {return true;}
+  if (repoExists(d, 'go.mod')) {return true;}
+  if (repoExists(d, 'Cargo.toml')) {return true;}
+  if (repoExists(d, 'Gemfile')) {return true;}
+  if (repoExists(d, 'pom.xml') || fileExists(d, 'build.gradle*')) {return true;}
   if (listRootCsprojs(d).length > 0) {return true;}
   const pkg = readPackageJson(d);
   if (pkg && Object.keys(pkg.dependencies ?? {}).length > 0) {return true;}
@@ -317,12 +292,13 @@ function hasLanguageManifest(d: string): boolean {
  *  real language manifest. This is NOT monorepo tooling — it only exists to stop
  *  a repo whose real stack lives in subdirs from falling to the `library` lie. */
 export function detectSubdirStacks(dir: string): SubdirStack[] {
-  let entries: Dirent[];
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return [];
-  }
+  // The project folder bounds every read below it: a subfolder's manifest may
+  // link anywhere inside the project, never out of it.
+  return withRepoRoot(dir, () => subdirStacks(dir));
+}
+
+function subdirStacks(dir: string): SubdirStack[] {
+  const entries = readRepoDir(dir) ?? [];
   const out: SubdirStack[] = [];
   for (const e of entries) {
     if (!e.isDirectory() || e.name.startsWith('.') || SUBDIR_IGNORE.has(e.name)) {continue;}
@@ -342,10 +318,10 @@ export function detectSubdirStacks(dir: string): SubdirStack[] {
       backend: !!be || BACKEND_LANG_RE.test(language),
       hasFramework: !!top,
       appRoot:
-        existsSync(join(sub, 'manage.py')) ||
-        existsSync(join(sub, 'config.ru')) ||
-        existsSync(join(sub, 'bin/rails')) ||
-        existsSync(join(sub, 'artisan')),
+        repoExists(sub, 'manage.py') ||
+        repoExists(sub, 'config.ru') ||
+        repoExists(sub, 'bin/rails') ||
+        repoExists(sub, 'artisan'),
     });
   }
   return out;
@@ -354,7 +330,7 @@ export function detectSubdirStacks(dir: string): SubdirStack[] {
 /** Polyglot signal — ≥2 sibling app dirs, ≥2 distinct languages, a frontend AND
  *  a backend among them. Returns the `# found:` evidence string, or null. */
 export function detectPolyglotSignal(dir: string, pkg: PackageJson | null): string | null {
-  if (pkg?.workspaces || existsSync(join(dir, 'pnpm-workspace.yaml'))) {return null;}
+  if (pkg?.workspaces || repoExists(dir, 'pnpm-workspace.yaml')) {return null;}
   const subs = detectSubdirStacks(dir);
   const langs = new Set(subs.map(s => s.language));
   if (subs.length < 2 || langs.size < 2) {return null;}
@@ -387,10 +363,10 @@ export function detectPolyglotLanguage(dir: string): string | null {
 
 /** Read and parse package.json from a directory */
 export function readPackageJson(dir: string): PackageJson | null {
-  const pkgPath = join(dir, 'package.json');
-  if (!existsSync(pkgPath)) {return null;}
+  const text = readRepoFile(dir, 'package.json');
+  if (text === null) {return null;}
   try {
-    return JSON.parse(readFileSync(pkgPath, 'utf-8'));
+    return JSON.parse(text);
   } catch {
     return null;
   }
@@ -400,7 +376,7 @@ export function readPackageJson(dir: string): PackageJson | null {
 function fileExists(dir: string, pattern: string): boolean {
   // Handle simple file checks
   if (!pattern.includes('*')) {
-    return existsSync(join(dir, pattern));
+    return repoExists(dir, pattern);
   }
 
   // Handle glob patterns like "next.config.*" or ".github/workflows/*.yml"
@@ -408,23 +384,15 @@ function fileExists(dir: string, pattern: string): boolean {
   if (parts.length === 1) {
     // Simple wildcard: "next.config.*"
     const prefix = pattern.split('*')[0];
-    try {
-      return readdirSync(dir).some(f => f.startsWith(prefix));
-    } catch {
-      return false;
-    }
+    return (readRepoDir(dir) ?? []).some(e => e.name.startsWith(prefix));
   }
 
   // Multi-level: ".github/workflows/*.yml"
-  const subdir = join(dir, ...parts.slice(0, -1));
+  const subdir = join(...parts.slice(0, -1));
   const filePattern = parts[parts.length - 1];
   const prefix = filePattern.split('*')[0];
   const suffix = filePattern.split('*')[1] || '';
-  try {
-    return readdirSync(subdir).some(f => f.startsWith(prefix) && f.endsWith(suffix));
-  } catch {
-    return false;
-  }
+  return (readRepoDir(dir, subdir) ?? []).some(e => e.name.startsWith(prefix) && e.name.endsWith(suffix));
 }
 
 /** Match a single signal against project data */
@@ -441,18 +409,9 @@ function matchSignal(signal: Signal, pkg: PackageJson | null, dir: string): bool
       // alone never claim Spring Boot — JVM Edition kill line for tech_stack.
       if (!signal.pattern || !signal.key) {return false;}
       if (!fileExists(dir, signal.pattern)) {return false;}
-      try {
-        // Resolve first match for globs like next.config.* via existing helper path
-        const path = join(dir, signal.pattern);
-        if (!existsSync(path)) {
-          // pattern may be a simple relative path that fileExists handled via glob
-          return false;
-        }
-        const body = readFileSync(path, 'utf-8').toLowerCase();
-        return body.includes(signal.key.toLowerCase());
-      } catch {
-        return false;
-      }
+      // A glob pattern names no one file: there is nothing to read, so no match.
+      const body = readRepoFile(dir, signal.pattern);
+      return body !== null && body.toLowerCase().includes(signal.key.toLowerCase());
     }
     default:
       return false;
@@ -480,22 +439,22 @@ export function detectLanguage(dir: string): string {
 
   // Check for TypeScript
   if (pkg?.devDependencies?.typescript || pkg?.dependencies?.typescript) {return 'TypeScript';}
-  if (existsSync(join(dir, 'tsconfig.json'))) {return 'TypeScript';}
+  if (repoExists(dir, 'tsconfig.json')) {return 'TypeScript';}
 
   // Check for common language indicators
-  if (existsSync(join(dir, 'Cargo.toml'))) {return 'Rust';}
-  if (existsSync(join(dir, 'go.mod'))) {return 'Go';}
+  if (repoExists(dir, 'Cargo.toml')) {return 'Rust';}
+  if (repoExists(dir, 'go.mod')) {return 'Go';}
   if (listRootCsprojs(dir).length > 0) {return 'C#';}
-  if (existsSync(join(dir, 'pyproject.toml')) || existsSync(join(dir, 'setup.py'))) {return 'Python';}
-  if (existsSync(join(dir, 'Gemfile'))) {return 'Ruby';}
+  if (repoExists(dir, 'pyproject.toml') || repoExists(dir, 'setup.py')) {return 'Python';}
+  if (repoExists(dir, 'Gemfile')) {return 'Ruby';}
   if (isJvmRoot(dir)) {
     const jvm = detectJvmProject(dir);
     if (jvm) {return jvm.mainLanguage === 'Java/Kotlin' ? 'Kotlin' : jvm.mainLanguage;}
     return 'Java';
   }
-  if (existsSync(join(dir, 'Package.swift'))) {return 'Swift';}
-  if (existsSync(join(dir, 'build.zig'))) {return 'Zig';}
-  if (existsSync(join(dir, 'pubspec.yaml'))) {return 'Dart';}
+  if (repoExists(dir, 'Package.swift')) {return 'Swift';}
+  if (repoExists(dir, 'build.zig')) {return 'Zig';}
+  if (repoExists(dir, 'pubspec.yaml')) {return 'Dart';}
 
   // A package.json with none of the manifests above: JavaScript
   if (pkg) {return 'JavaScript';}
@@ -652,13 +611,13 @@ export function detectProjectTypeWithRationale(dir: string): ProjectTypeDetectio
   // Zig project-type detection — build.zig + entry-file convention.
   // src/main.zig → cli (executable); src/root.zig → library.
   // main.zig wins when both exist (typical: cli with internal lib exports).
-  if (existsSync(join(dir, 'build.zig'))) {
+  if (repoExists(dir, 'build.zig')) {
     found.push('build.zig');
-    if (existsSync(join(dir, 'src/main.zig'))) {
+    if (repoExists(dir, 'src/main.zig')) {
       found.push('src/main.zig');
       return { type: 'cli', found };
     }
-    if (existsSync(join(dir, 'src/root.zig'))) {
+    if (repoExists(dir, 'src/root.zig')) {
       found.push('src/root.zig');
       return { type: 'library', found };
     }
@@ -667,7 +626,7 @@ export function detectProjectTypeWithRationale(dir: string): ProjectTypeDetectio
   // ─── 10. framework — private workspace + Svelte ──────────────────────────
   const hasSvelte = frameworks.some(f => f.slug === 'svelte' || f.slug === 'sveltekit');
   const isPrivateWorkspace = pkg?.private === true && (
-    existsSync(join(dir, 'pnpm-workspace.yaml')) ||
+    repoExists(dir, 'pnpm-workspace.yaml') ||
     pkg?.workspaces !== undefined
   );
   if (isPrivateWorkspace && hasSvelte) {
@@ -687,7 +646,7 @@ export function detectProjectTypeWithRationale(dir: string): ProjectTypeDetectio
   const hasBackendFw = frameworks.some(f => f.category === 'backend');
   if (
     pkg?.private &&
-    (pkg.workspaces || existsSync(join(dir, 'pnpm-workspace.yaml'))) &&
+    (pkg.workspaces || repoExists(dir, 'pnpm-workspace.yaml')) &&
     hasFrontendFw && hasBackendFw
   ) {
     found.push('private workspace + frontend + backend frameworks');
@@ -781,13 +740,13 @@ export function detectProjectType(dir: string): string {
 /** Detect the runtime from a runtime file or manifest — `''` when there is
  *  no evidence. */
 export function detectRuntime(dir: string): string {
-  if (existsSync(join(dir, 'bunfig.toml'))) {return 'Bun';}
-  if (existsSync(join(dir, 'deno.json')) || existsSync(join(dir, 'deno.jsonc'))) {return 'Deno';}
+  if (repoExists(dir, 'bunfig.toml')) {return 'Bun';}
+  if (repoExists(dir, 'deno.json') || repoExists(dir, 'deno.jsonc')) {return 'Deno';}
   if (readPackageJson(dir)) {return 'Node.js';}
-  if (existsSync(join(dir, 'Cargo.toml'))) {return 'Rust';}
-  if (existsSync(join(dir, 'go.mod'))) {return 'Go';}
+  if (repoExists(dir, 'Cargo.toml')) {return 'Rust';}
+  if (repoExists(dir, 'go.mod')) {return 'Go';}
   if (listRootCsprojs(dir).length > 0) {return '.NET';}
-  if (existsSync(join(dir, 'pubspec.yaml'))) {return 'Dart';}
+  if (repoExists(dir, 'pubspec.yaml')) {return 'Dart';}
   return '';
 }
 
@@ -805,12 +764,12 @@ function declaredPackageManager(dir: string): string {
 
 /** The package manager a non-JS manifest implies, or `''`. */
 function manifestPackageManager(dir: string): string {
-  if (existsSync(join(dir, 'pubspec.yaml'))) {return 'pub';}
-  if (existsSync(join(dir, 'go.mod'))) {return 'go modules';}
+  if (repoExists(dir, 'pubspec.yaml')) {return 'pub';}
+  if (repoExists(dir, 'go.mod')) {return 'go modules';}
   if (listRootCsprojs(dir).length > 0) {return 'NuGet';}
-  if (existsSync(join(dir, 'pom.xml'))) {return 'maven';}
+  if (repoExists(dir, 'pom.xml')) {return 'maven';}
   const gradle = ['build.gradle', 'build.gradle.kts', 'settings.gradle', 'settings.gradle.kts'];
-  return gradle.some(f => existsSync(join(dir, f))) ? 'gradle' : '';
+  return gradle.some(f => repoExists(dir, f)) ? 'gradle' : '';
 }
 
 /** The JS package manager a committed lockfile names, or `''`. */
@@ -822,55 +781,50 @@ const LOCKFILES: ReadonlyArray<[file: string, manager: string]> = [
  *  package.json's `packageManager` field, then a lockfile. `''` when there is
  *  no evidence: a package.json alone does not say which manager installs it. */
 export function detectPackageManager(dir: string): string {
-  return manifestPackageManager(dir) || declaredPackageManager(dir) || (LOCKFILES.find(([f]) => existsSync(join(dir, f)))?.[1] ?? '');
+  return manifestPackageManager(dir) || declaredPackageManager(dir) || (LOCKFILES.find(([f]) => repoExists(dir, f))?.[1] ?? '');
 }
 
 /** Detect CI/CD */
 export function detectCicd(dir: string): string | null {
-  if (existsSync(join(dir, '.github/workflows'))) {return 'GitHub Actions';}
-  if (existsSync(join(dir, '.gitlab-ci.yml'))) {return 'GitLab CI';}
-  if (existsSync(join(dir, '.circleci'))) {return 'CircleCI';}
-  if (existsSync(join(dir, 'Jenkinsfile'))) {return 'Jenkins';}
+  if (repoExists(dir, '.github/workflows')) {return 'GitHub Actions';}
+  if (repoExists(dir, '.gitlab-ci.yml')) {return 'GitLab CI';}
+  if (repoExists(dir, '.circleci')) {return 'CircleCI';}
+  if (repoExists(dir, 'Jenkinsfile')) {return 'Jenkins';}
   return null;
 }
 
 /** Detect hosting platform — from a platform's own config file. A bare
  *  Dockerfile is not one: it shows a container build, not where the app runs. */
 export function detectHosting(dir: string): string | null {
-  if (existsSync(join(dir, 'vercel.json'))) {return 'Vercel';}
-  if (existsSync(join(dir, 'netlify.toml'))) {return 'Netlify';}
-  if (existsSync(join(dir, 'wrangler.toml'))) {return 'Cloudflare';}
-  if (existsSync(join(dir, 'fly.toml'))) {return 'Fly.io';}
-  if (existsSync(join(dir, 'render.yaml'))) {return 'Render';}
+  if (repoExists(dir, 'vercel.json')) {return 'Vercel';}
+  if (repoExists(dir, 'netlify.toml')) {return 'Netlify';}
+  if (repoExists(dir, 'wrangler.toml')) {return 'Cloudflare';}
+  if (repoExists(dir, 'fly.toml')) {return 'Fly.io';}
+  if (repoExists(dir, 'render.yaml')) {return 'Render';}
   return null;
 }
 
 /** Detect SvelteKit adapter from svelte.config.js */
 export function detectSvelteAdapter(dir: string): string | null {
-  const configPath = join(dir, 'svelte.config.js');
-  if (!existsSync(configPath)) {return null;}
-  try {
-    const content = readFileSync(configPath, 'utf-8');
-    // Match adapter imports: import adapter from '@sveltejs/adapter-vercel'
-    // Or: import { adapter } from '@sveltejs/adapter-node'
-    // Or: const adapter = require('@sveltejs/adapter-static')
-    const adapterMatch = content.match(/@sveltejs\/adapter-(\w+)/);
-    if (adapterMatch) {
-      const adapter = adapterMatch[1];
-      switch (adapter) {
-        case 'vercel': return 'Vercel';
-        case 'node': return 'Node';
-        case 'static': return 'Static';
-        case 'cloudflare': return 'Cloudflare';
-        case 'netlify': return 'Netlify';
-        case 'auto': return 'Auto';
-        default: return adapter;
-      }
+  const content = readRepoFile(dir, 'svelte.config.js');
+  if (content === null) {return null;}
+  // Match adapter imports: import adapter from '@sveltejs/adapter-vercel'
+  // Or: import { adapter } from '@sveltejs/adapter-node'
+  // Or: const adapter = require('@sveltejs/adapter-static')
+  const adapterMatch = content.match(/@sveltejs\/adapter-(\w+)/);
+  if (adapterMatch) {
+    const adapter = adapterMatch[1];
+    switch (adapter) {
+      case 'vercel': return 'Vercel';
+      case 'node': return 'Node';
+      case 'static': return 'Static';
+      case 'cloudflare': return 'Cloudflare';
+      case 'netlify': return 'Netlify';
+      case 'auto': return 'Auto';
+      default: return adapter;
     }
-    return null;
-  } catch {
-    return null;
   }
+  return null;
 }
 
 /** Detect build tool */
@@ -879,7 +833,7 @@ export function detectBuildTool(dir: string): string | null {
   if (pkg?.devDependencies?.vite || pkg?.dependencies?.vite) {return 'Vite';}
   if (pkg?.devDependencies?.webpack || pkg?.dependencies?.webpack) {return 'webpack';}
   if (pkg?.devDependencies?.esbuild || pkg?.dependencies?.esbuild) {return 'esbuild';}
-  if (existsSync(join(dir, 'tsconfig.json')) && pkg?.devDependencies?.typescript) {return 'TypeScript (tsc)';}
+  if (repoExists(dir, 'tsconfig.json') && pkg?.devDependencies?.typescript) {return 'TypeScript (tsc)';}
   return null;
 }
 
@@ -913,7 +867,7 @@ export function detectKeyFiles(dir: string): string[] {
     // Config
     'tsconfig.json', 'wrangler.toml', 'vercel.json',
   ];
-  return candidates.filter(f => existsSync(join(dir, f)));
+  return candidates.filter(f => repoExists(dir, f));
 }
 
 /** Detect build/test/lint commands for the COMMANDS FAFB section.
@@ -926,7 +880,7 @@ export function detectCommands(dir: string, pkg: PackageJson | null): Record<str
     for (const key of ['build', 'test', 'lint', 'dev', 'start']) {
       if (pkg.scripts[key]) {
         // Determine the runner — prefer bun if available, else npm
-        const runner = existsSync(join(dir, 'bun.lock')) || existsSync(join(dir, 'bun.lockb'))
+        const runner = repoExists(dir, 'bun.lock') || repoExists(dir, 'bun.lockb')
           ? 'bun run'
           : 'npm run';
         commands[key] = `${runner} ${key}`;
@@ -936,7 +890,7 @@ export function detectCommands(dir: string, pkg: PackageJson | null): Record<str
 
   // Rust: cargo builds and tests every Cargo package. Clippy only when the
   // repo configures it — a Cargo.toml alone does not say the project lints with it.
-  if (existsSync(join(dir, 'Cargo.toml'))) {
+  if (repoExists(dir, 'Cargo.toml')) {
     if (!commands.build) {commands.build = 'cargo build --release';}
     if (!commands.test) {commands.test = 'cargo test';}
     if (!commands.lint && configuresClippy(dir)) {commands.lint = 'cargo clippy';}
@@ -944,13 +898,13 @@ export function detectCommands(dir: string, pkg: PackageJson | null): Record<str
 
   // Zig: build.zig is `zig build`'s own script; `zig build test` only when
   // it defines a test step.
-  if (existsSync(join(dir, 'build.zig'))) {
+  if (repoExists(dir, 'build.zig')) {
     if (!commands.build) {commands.build = 'zig build';}
     if (!commands.test && /\.step\(\s*"test"/.test(readText(dir, 'build.zig'))) {commands.test = 'zig build test';}
   }
 
   // Go: the go tool builds and tests every module.
-  if (existsSync(join(dir, 'go.mod'))) {
+  if (repoExists(dir, 'go.mod')) {
     if (!commands.build) {commands.build = 'go build ./...';}
     if (!commands.test) {commands.test = 'go test ./...';}
   }
@@ -964,23 +918,19 @@ export function detectCommands(dir: string, pkg: PackageJson | null): Record<str
 
 /** A file's text, or `''` when it cannot be read. */
 function readText(dir: string, name: string): string {
-  try {
-    return readFileSync(join(dir, name), 'utf-8');
-  } catch {
-    return '';
-  }
+  return readRepoFile(dir, name) ?? '';
 }
 
 /** The repo configures Clippy: a clippy.toml, or a `[lints.clippy]` table in Cargo.toml. */
 function configuresClippy(dir: string): boolean {
-  if (existsSync(join(dir, 'clippy.toml')) || existsSync(join(dir, '.clippy.toml'))) {return true;}
+  if (repoExists(dir, 'clippy.toml') || repoExists(dir, '.clippy.toml')) {return true;}
   return /^\s*\[(workspace\.)?lints\.clippy\]/m.test(readText(dir, 'Cargo.toml'));
 }
 
 /** The repo says pytest: pytest.ini or conftest.py, or pytest named in
  *  pyproject.toml, setup.cfg or tox.ini (its config table or a dependency). */
 function usesPytest(dir: string): boolean {
-  if (existsSync(join(dir, 'pytest.ini')) || existsSync(join(dir, 'conftest.py'))) {return true;}
+  if (repoExists(dir, 'pytest.ini') || repoExists(dir, 'conftest.py')) {return true;}
   return ['pyproject.toml', 'setup.cfg', 'tox.ini'].some(f => /\bpytest\b/.test(readText(dir, f)));
 }
 
@@ -1007,8 +957,8 @@ export function detectTechStack(
   }
 
   // Runtime if non-trivial (Node.js by default for JS — only call out Bun/Deno/etc.)
-  if (existsSync(join(dir, 'bunfig.toml'))) {stack.push('Bun');}
-  else if (existsSync(join(dir, 'deno.json')) || existsSync(join(dir, 'deno.jsonc'))) {stack.push('Deno');}
+  if (repoExists(dir, 'bunfig.toml')) {stack.push('Bun');}
+  else if (repoExists(dir, 'deno.json') || repoExists(dir, 'deno.jsonc')) {stack.push('Deno');}
 
   // Top deps from package.json/Cargo.toml — only if stack is still sparse
   if (stack.length < 3 && pkg?.dependencies) {

--- a/src/detect/swift.ts
+++ b/src/detect/swift.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
+import { readRepoDir, readRepoFile, repoExists, statRepoFile } from '../core/safe-write.js';
 import spec from './swift-detection.json';
 
 /**
@@ -55,31 +55,14 @@ export interface PackageSwiftSignals {
 
 /** True if directory looks like a Swift project root. */
 export function isSwiftRoot(dir: string): boolean {
-  return existsSync(join(dir, 'Package.swift')) || listXcodeprojs(dir).length > 0;
+  return repoExists(dir, 'Package.swift') || listXcodeprojs(dir).length > 0;
 }
 
 /** Root-level *.xcodeproj directory names. */
 export function listXcodeprojs(dir: string): string[] {
-  try {
-    return readdirSync(dir).filter(f => {
-      if (!f.endsWith('.xcodeproj')) {return false;}
-      try {
-        return statSync(join(dir, f)).isDirectory();
-      } catch {
-        return false;
-      }
-    });
-  } catch {
-    return [];
-  }
-}
-
-function readText(path: string): string | null {
-  try {
-    return readFileSync(path, 'utf-8');
-  } catch {
-    return null;
-  }
+  return (readRepoDir(dir) ?? [])
+    .map(e => e.name)
+    .filter(f => f.endsWith('.xcodeproj') && statRepoFile(dir, f)?.isDirectory() === true);
 }
 
 /**
@@ -242,8 +225,7 @@ export function scanXcodeProductTypes(dir: string): {
   let hasTool = false;
   let hit: string | undefined;
   for (const xp of listXcodeprojs(dir)) {
-    const pbx = join(dir, xp, 'project.pbxproj');
-    const body = readText(pbx);
+    const body = readRepoFile(dir, join(xp, 'project.pbxproj'));
     if (!body) {continue;}
     for (const t of APP_PRODUCT_TYPES) {
       if (body.includes(t)) {
@@ -263,7 +245,7 @@ export function scanXcodeProductTypes(dir: string): {
 
 function vaporLayoutHit(dir: string): string | undefined {
   for (const rel of VAPOR_LAYOUT) {
-    if (existsSync(join(dir, rel))) {return rel;}
+    if (repoExists(dir, rel)) {return rel;}
   }
   return undefined;
 }
@@ -275,14 +257,13 @@ function vaporLayoutHit(dir: string): string | undefined {
 export function detectSwiftProject(dir: string): SwiftProject | null {
   if (!isSwiftRoot(dir)) {return null;}
 
-  const pkgPath = join(dir, 'Package.swift');
-  const hasPkg = existsSync(pkgPath);
+  const hasPkg = repoExists(dir, 'Package.swift');
   const xcodeprojs = listXcodeprojs(dir);
   const hasXcode = xcodeprojs.length > 0;
 
   let signals: PackageSwiftSignals | null = null;
   if (hasPkg) {
-    const body = readText(pkgPath);
+    const body = readRepoFile(dir, 'Package.swift');
     if (body) {signals = parsePackageSwift(body);}
   }
 

--- a/src/detect/turbo-cat.ts
+++ b/src/detect/turbo-cat.ts
@@ -15,8 +15,9 @@
  * Turbo-Cat fills only the slots still empty (esp. non-npm stacks).
  */
 
-import { readdirSync, readFileSync, statSync, type Dirent } from 'fs';
+import type { Dirent } from 'fs';
 import { join, extname, resolve } from 'path';
+import { readRepoDir, readRepoFile, statRepoFile, withRepoRoot } from '../core/safe-write.js';
 import { KNOWLEDGE_BASE } from './turbo-cat-knowledge.js';
 import { detectDartProject } from './dart.js';
 import { detectGoProject } from './go.js';
@@ -126,9 +127,9 @@ function categoryFor(slots: Record<string, string>, frameworks: string[]): strin
  *   pwa     — start_url/display/icons → assert nothing
  *   unknown/unreadable → assert NOTHING. An honest empty beats a guessed stack.
  */
-function classifyManifestJson(filePath: string): 'chrome' | 'other' {
+function classifyManifestJson(dir: string, name: string): 'chrome' | 'other' {
   try {
-    const m = JSON.parse(readFileSync(filePath, 'utf-8')) as Record<string, unknown>;
+    const m = JSON.parse(readRepoFile(dir, name) ?? '') as Record<string, unknown>;
     const chromeField = ['background', 'content_scripts', 'action', 'browser_action', 'permissions']
       .some((k) => k in m);
     if (typeof m.manifest_version === 'number' && chromeField) {return 'chrome';}
@@ -138,27 +139,20 @@ function classifyManifestJson(filePath: string): 'chrome' | 'other' {
   }
 }
 
-/** A directory entry that is a regular file (a link counts when it leads to one).
+/** A directory entry that is a regular file (a link counts when it leads to one
+ *  inside the project; a dangling link, or one out of it, does not).
  *  A folder named `go.mod` or `package.json` is not evidence of anything. */
 function isFileEntry(dir: string, e: Dirent): boolean {
   if (e.isFile()) {return true;}
   if (!e.isSymbolicLink()) {return false;}
-  try {
-    return statSync(join(dir, e.name)).isFile();
-  } catch {
-    return false; // dangling link
-  }
+  return statRepoFile(dir, e.name)?.isFile() === true;
 }
 
-/** A directory entry that is a folder (a link counts when it leads to one). */
+/** A directory entry that is a folder (a link counts when it leads to one inside the project). */
 function isDirEntry(dir: string, e: Dirent): boolean {
   if (e.isDirectory()) {return true;}
   if (!e.isSymbolicLink()) {return false;}
-  try {
-    return statSync(join(dir, e.name)).isDirectory();
-  } catch {
-    return false;
-  }
+  return statRepoFile(dir, e.name)?.isDirectory() === true;
 }
 
 /** Layer 1A — config files in the project directory only. Never a parent:
@@ -169,12 +163,8 @@ function scanConfigFiles(projectDir: string): FoundFormat[] {
   const cur = resolve(projectDir);
   /** One JVM classification per directory (pom + gradle + settings would triple-fire). */
   const jvmDirsDone = new Set<string>();
-  let entries: Dirent[];
-  try {
-    entries = readdirSync(cur, { withFileTypes: true });
-  } catch {
-    return found;
-  }
+  const entries = readRepoDir(cur);
+  if (!entries) {return found;}
   for (const e of entries) {
     const f = e.name;
     // Content-aware: *.xcodeproj is a folder (checked below); every other
@@ -237,7 +227,7 @@ function scanConfigFiles(projectDir: string): FoundFormat[] {
     if (!k) {continue;}
     // Sourced-only gate: manifest.json only asserts the chrome stack when
     // its CONTENT proves a chrome extension; mcpb/PWA/unknown assert nothing.
-    if (f === 'manifest.json' && classifyManifestJson(join(cur, f)) !== 'chrome') {continue;}
+    if (f === 'manifest.json' && classifyManifestJson(cur, f) !== 'chrome') {continue;}
     // Content-aware: pubspec.yaml backs Flutter apps, Dart CLIs/packages,
     // servers, and MCP servers — branch by deps instead of asserting Flutter
     // for everything (the filename-only flattening this engine used to do).
@@ -383,7 +373,7 @@ function scanConfigFiles(projectDir: string): FoundFormat[] {
  *  come from config files, Layer 1A). */
 function scanExtensions(projectDir: string): FoundFormat[] {
   const found: FoundFormat[] = [];
-  for (const ext of collectExtensions(projectDir, 2, { count: 0 })) {
+  for (const ext of withRepoRoot(projectDir, () => collectExtensions(projectDir, 2, { count: 0 }))) {
     const k = KNOWLEDGE_BASE[`*${ext}`];
     const lang = (k?.slots as Record<string, string> | undefined)?.mainLanguage;
     if (lang) {found.push({ slots: { mainLanguage: lang }, priority: k.priority, frameworks: k.frameworks });}
@@ -453,12 +443,8 @@ export function turboCatSlots(projectDir: string): { project?: Record<string, st
 function collectExtensions(dir: string, depth: number, budget: { count: number }): Set<string> {
   const exts = new Set<string>();
   if (depth < 0 || budget.count > 400) {return exts;}
-  let entries: import('fs').Dirent[];
-  try {
-    entries = readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return exts;
-  }
+  const entries = readRepoDir(dir);
+  if (!entries) {return exts;}
   for (const e of entries) {
     if (budget.count++ > 400) {break;}
     if (!e.isDirectory()) {

--- a/src/interop/cards.ts
+++ b/src/interop/cards.ts
@@ -1,9 +1,9 @@
-import { existsSync, readFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { existsSync } from 'fs';
+import { basename, dirname, join } from 'path';
 import { deprecate } from 'node:util';
 import { parse } from 'yaml';
 import type { FafData } from '../core/types.js';
-import { makeDirInside } from '../core/safe-write.js';
+import { makeDirInside, readUtf8, resolveInside } from '../core/safe-write.js';
 import { writeRendered, type RenderedResult } from '../core/render-hash.js';
 import { upsertJsonRows } from '../core/json-edit.js';
 import {
@@ -124,7 +124,10 @@ export interface ProjectedCards {
 }
 
 export function readFafa(path: string): FafaDoc {
-  return parse(readFileSync(path, 'utf-8')) as FafaDoc;
+  // A .fafa that links out of its folder is refused (SafePathError), never read:
+  // a hostile repo's agent.fafa -> ~/.aws/credentials would otherwise be parsed
+  // and quoted in an error. A link to a same-name file inside the folder is fine.
+  return parse(readUtf8(resolveInside(dirname(path), basename(path)))) as FafaDoc;
 }
 
 /** Discover agent.fafa / .fafa (cwd, then one parent). */

--- a/src/interrogate/build-files.ts
+++ b/src/interrogate/build-files.ts
@@ -7,8 +7,8 @@
  * obvious ones. Facts from files, not README prose.
  */
 
-import { existsSync, readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
+import { readRepoDir, readRepoFile, repoExists, withRepoRoot } from '../core/safe-write.js';
 import type { ExtractedContext } from './types.js';
 
 const IGNORE_DIRS = new Set([
@@ -57,35 +57,37 @@ function pick(targets: string[], patterns: RegExp[]): string | null {
 /** Root, then each depth-1 subdir (so a nested `backend/Makefile` is found). */
 function buildFileDirs(dir: string): string[] {
   const dirs = [dir];
-  try {
-    for (const e of readdirSync(dir, { withFileTypes: true })) {
-      if (e.isDirectory() && !e.name.startsWith('.') && !IGNORE_DIRS.has(e.name)) {
-        dirs.push(join(dir, e.name));
-      }
+  for (const e of readRepoDir(dir) ?? []) { // unreadable: root only
+    if (e.isDirectory() && !e.name.startsWith('.') && !IGNORE_DIRS.has(e.name)) {
+      dirs.push(join(dir, e.name));
     }
-  } catch { /* unreadable — root only */ }
+  }
   return dirs;
 }
 
 /** Does `d` look like the primary backend/app dir? (raises its command priority) */
 function looksPrimary(d: string): number {
   let s = 0;
-  if (existsSync(join(d, 'manage.py')) || existsSync(join(d, 'pyproject.toml')) || existsSync(join(d, 'Gemfile'))) {s += 3;}
+  if (repoExists(d, 'manage.py') || repoExists(d, 'pyproject.toml') || repoExists(d, 'Gemfile')) {s += 3;}
   if (/(?:^|\/)(backend|api|server|core|app)$/.test(d)) {s += 2;}
   return s;
 }
 
 export function interrogateBuildFiles(dir: string): ExtractedContext {
+  // The project folder bounds the subfolder reads: a nested Makefile may link
+  // anywhere inside the project, never out of it.
+  return withRepoRoot(dir, () => buildFileContext(dir));
+}
+
+function buildFileContext(dir: string): ExtractedContext {
   const candidates: Array<{ score: number; commands: Record<string, string> }> = [];
 
   for (const scanDir of buildFileDirs(dir)) {
     const isRoot = scanDir === dir;
     const prefix = isRoot ? '' : `cd ${scanDir.slice(dir.length + 1)} && `;
     for (const bf of BUILD_FILES) {
-      const path = join(scanDir, bf.file);
-      if (!existsSync(path)) {continue;}
-      let body: string;
-      try { body = readFileSync(path, 'utf-8'); } catch { continue; }
+      const body = readRepoFile(scanDir, bf.file);
+      if (body === null) {continue;}
       const targets = bf.targets(body);
       if (targets.length === 0) {continue;}
 

--- a/src/interrogate/cargo.ts
+++ b/src/interrogate/cargo.ts
@@ -6,8 +6,7 @@
  * `project.goal` (overarching/use-case framing).
  */
 
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { readRepoFile } from '../core/safe-write.js';
 import { type ExtractedContext, isValidExtraction } from './types.js';
 
 /** Parse a single TOML field from `[package]` table. Naive but adequate for
@@ -41,15 +40,8 @@ function readPackageField(content: string, field: string): string | null {
 
 /** Read Cargo.toml and extract per-slot content. Returns {} if no Cargo.toml. */
 export function interrogateCargo(dir: string): ExtractedContext {
-  const path = join(dir, 'Cargo.toml');
-  if (!existsSync(path)) {return {};}
-
-  let content: string;
-  try {
-    content = readFileSync(path, 'utf-8');
-  } catch {
-    return {};
-  }
+  const content = readRepoFile(dir, 'Cargo.toml');
+  if (content === null) {return {};}
 
   const description = readPackageField(content, 'description');
   if (description && isValidExtraction(description)) {

--- a/src/interrogate/compose.ts
+++ b/src/interrogate/compose.ts
@@ -7,8 +7,8 @@
  * images onto stack slots. Facts, not prose — so these win over README guesses.
  */
 
-import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
+import { readRepoDir, readRepoFile } from '../core/safe-write.js';
 import type { ExtractedContext } from './types.js';
 
 /** image name (before ':' tag, after last '/') → { slot, label }. */
@@ -39,20 +39,18 @@ const IGNORE_DIRS = new Set([
   'node_modules', '.git', 'dist', 'build', 'vendor', 'target', 'e2e', 'tests', 'test',
 ]);
 
-/** Every compose file at root + one directory deep. */
+/** Every compose file at root + one directory deep (paths relative to `dir`). */
 function findComposeFiles(dir: string): string[] {
   const out: string[] = [];
   const scan = (d: string, depth: number): void => {
-    let entries: import('fs').Dirent[];
-    try { entries = readdirSync(d, { withFileTypes: true }); } catch { return; }
-    for (const e of entries) {
+    for (const e of readRepoDir(dir, d) ?? []) {
       if (e.isFile() && /^(docker-)?compose.*\.ya?ml$/i.test(e.name)) {out.push(join(d, e.name));}
       else if (e.isDirectory() && depth > 0 && !e.name.startsWith('.') && !IGNORE_DIRS.has(e.name)) {
         scan(join(d, e.name), depth - 1);
       }
     }
   };
-  scan(dir, 1);
+  scan('.', 1);
   return out;
 }
 
@@ -71,8 +69,8 @@ export function interrogateCompose(dir: string): ExtractedContext {
   };
 
   for (const file of files) {
-    let body: string;
-    try { body = readFileSync(file, 'utf-8'); } catch { continue; }
+    const body = readRepoFile(dir, file);
+    if (body === null) {continue;}
     for (const m of body.matchAll(/^\s*image:\s*["']?([^\s"'#]+)/gm)) {
       const ref = m[1].toLowerCase();
       // strip registry host + tag: ghcr.io/foo/redis:7-alpine → redis

--- a/src/interrogate/env.ts
+++ b/src/interrogate/env.ts
@@ -5,8 +5,7 @@
  * in `.env`, this file is the template. Fills `security.secrets` + `.example`.
  */
 
-import { existsSync } from 'fs';
-import { join } from 'path';
+import { repoExists } from '../core/safe-write.js';
 import type { ExtractedContext } from './types.js';
 
 const CANDIDATES = [
@@ -16,7 +15,7 @@ const CANDIDATES = [
 
 export function interrogateEnv(dir: string): ExtractedContext {
   for (const rel of CANDIDATES) {
-    if (existsSync(join(dir, rel))) {
+    if (repoExists(dir, rel)) {
       return { security: { secrets: '.env', example: rel } };
     }
   }

--- a/src/interrogate/readme.ts
+++ b/src/interrogate/readme.ts
@@ -7,8 +7,7 @@
  *   No slot is synthesized from another slot's content.
  */
 
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { readRepoFile, repoExists } from '../core/safe-write.js';
 import { type ExtractedContext, isValidExtraction } from './types.js';
 
 /** Strip badge / image lines + blank lines from the top of a README */
@@ -145,17 +144,12 @@ export function interrogateReadme(dir: string): ExtractedContext {
   const candidates = ['README.md', 'README.MD', 'Readme.md', 'readme.md'];
   let path: string | null = null;
   for (const name of candidates) {
-    const full = join(dir, name);
-    if (existsSync(full)) { path = full; break; }
+    if (repoExists(dir, name)) { path = name; break; }
   }
   if (!path) {return {};}
 
-  let content: string;
-  try {
-    content = readFileSync(path, 'utf-8');
-  } catch {
-    return {};
-  }
+  let content = readRepoFile(dir, path);
+  if (content === null) {return {};}
   // HTML comment blocks (asset notes, TODO markers, marketing briefs) are not
   // prose — strip before any extraction so their text can't seed a slot.
   content = content.replace(/<!--[\s\S]*?-->/g, '');

--- a/tests/core/repo-file.test.ts
+++ b/tests/core/repo-file.test.ts
@@ -1,0 +1,135 @@
+/**
+ * BRAKE: repoFile — the one helper every detection read goes through (7.13.1).
+ *
+ * repoFile(dir, rel) resolves `rel` on disk, every link followed (the folders
+ * on the way included). When the real path leaves `dir`, runs through `.git`,
+ * or a link on the way dangles or loops, detection treats the file as absent:
+ * repoExists → false, readRepoFile / statRepoFile / repoFile → null, and
+ * readRepoDir leaves such a link out of a listing. A link that stays inside
+ * the project is followed. Every folder here is a mkdtemp folder.
+ */
+import { afterAll, describe, test, expect } from 'bun:test';
+import { mkdirSync, realpathSync, symlinkSync, writeFileSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { readRepoDir, readRepoFile, repoExists, repoFile, statRepoFile } from '../../src/core/safe-write.js';
+import { tempDirs } from '../helpers/temp-dirs.js';
+
+const tempFolders = tempDirs();
+afterAll(() => tempFolders.removeAll());
+
+const posix = process.platform !== 'win32';
+const SECRET = 'aws_secret_access_key = OUTSIDE-SECRET-DO-NOT-READ\n';
+
+/** A project folder, and a folder outside it holding a secret file. */
+function fixture(): { dir: string; outside: string; secret: string } {
+  const dir = realpathSync(tempFolders.mkdtemp(join(tmpdir(), 'faf-repofile-')));
+  const outside = realpathSync(tempFolders.mkdtemp(join(tmpdir(), 'faf-repofile-outside-')));
+  const secret = join(outside, 'credentials');
+  writeFileSync(secret, SECRET);
+  return { dir, outside, secret };
+}
+
+function put(dir: string, rel: string, text: string): void {
+  mkdirSync(dirname(join(dir, rel)), { recursive: true });
+  writeFileSync(join(dir, rel), text);
+}
+
+/** Every way detection can ask about `rel` says it is absent. */
+function expectAbsent(dir: string, rel: string): void {
+  expect(repoFile(dir, rel)).toBeNull();
+  expect(repoExists(dir, rel)).toBe(false);
+  expect(readRepoFile(dir, rel)).toBeNull();
+  expect(statRepoFile(dir, rel)).toBeNull();
+}
+
+describe('BRAKE: repoFile — detection reads stay inside the project', () => {
+  test('a file in the project is found and read', () => {
+    const { dir } = fixture();
+    put(dir, 'README.md', '# Demo\n');
+    expect(repoFile(dir, 'README.md')).toBe(join(dir, 'README.md'));
+    expect(repoExists(dir, 'README.md')).toBe(true);
+    expect(readRepoFile(dir, 'README.md')).toBe('# Demo\n');
+    expect(statRepoFile(dir, 'README.md')?.isFile()).toBe(true);
+  });
+
+  test('a file that is not there is absent', () => {
+    const { dir } = fixture();
+    expectAbsent(dir, 'README.md');
+    expect(readRepoDir(dir, 'docs')).toBeNull();
+  });
+
+  test('a folder is found; reading it as a file gives nothing', () => {
+    const { dir } = fixture();
+    put(dir, '.github/workflows/ci.yml', 'on: push\n');
+    expect(repoExists(dir, '.github/workflows')).toBe(true);
+    expect(statRepoFile(dir, '.github/workflows')?.isDirectory()).toBe(true);
+    expect(readRepoFile(dir, '.github/workflows')).toBeNull();
+    expect(readRepoDir(dir, '.github/workflows')?.map(e => e.name)).toEqual(['ci.yml']);
+  });
+
+  test.skipIf(!posix)('a link to a file outside the project is absent, and left out of a listing', () => {
+    const { dir, secret } = fixture();
+    symlinkSync(secret, join(dir, 'README.md'));
+    put(dir, 'index.ts', 'export {};\n');
+    expectAbsent(dir, 'README.md');
+    expect(readRepoDir(dir)?.map(e => e.name)).toEqual(['index.ts']);
+  });
+
+  test.skipIf(!posix)('a relative link that climbs out of the project is absent', () => {
+    const { dir, outside } = fixture();
+    symlinkSync(join('..', basename(outside), 'credentials'), join(dir, 'package.json'));
+    expectAbsent(dir, 'package.json');
+    expectAbsent(dir, join('..', basename(outside), 'credentials'));
+  });
+
+  test.skipIf(!posix)('a file in a folder that is a link out of the project is absent', () => {
+    const { dir, outside } = fixture();
+    writeFileSync(join(outside, 'README.md'), SECRET);
+    symlinkSync(outside, join(dir, 'docs'));
+    expectAbsent(dir, 'docs');
+    expectAbsent(dir, 'docs/README.md');
+    expect(readRepoDir(dir, 'docs')).toBeNull();
+    expect(readRepoDir(dir)?.map(e => e.name)).toEqual([]);
+  });
+
+  test.skipIf(!posix)('a dangling link and a link loop are absent', () => {
+    const { dir } = fixture();
+    symlinkSync(join(dir, 'nowhere.md'), join(dir, 'README.md'));
+    symlinkSync('b.json', join(dir, 'a.json'));
+    symlinkSync('a.json', join(dir, 'b.json'));
+    expectAbsent(dir, 'README.md');
+    expectAbsent(dir, 'a.json');
+    expect(readRepoDir(dir)?.map(e => e.name)).toEqual([]);
+  });
+
+  test.skipIf(!posix)('anything in .git is absent, a link into .git included', () => {
+    const { dir } = fixture();
+    put(dir, '.git/config', SECRET);
+    symlinkSync(join('.git', 'config'), join(dir, 'README.md'));
+    expectAbsent(dir, '.git/config');
+    expectAbsent(dir, '.git');
+    expectAbsent(dir, 'README.md');
+  });
+
+  test.skipIf(!posix)('a link that stays inside the project is followed (README.md → docs/README.md)', () => {
+    const { dir } = fixture();
+    put(dir, 'docs/README.md', '# In-project README\n');
+    symlinkSync(join('docs', 'README.md'), join(dir, 'README.md'));
+    put(dir, 'src/cmd/main.go', 'package main\n');
+    symlinkSync(join('src', 'cmd'), join(dir, 'cmd'));
+    expect(repoFile(dir, 'README.md')).toBe(join(dir, 'docs', 'README.md'));
+    expect(readRepoFile(dir, 'README.md')).toBe('# In-project README\n');
+    expect(readRepoDir(dir, 'cmd')?.map(e => e.name)).toEqual(['main.go']);
+    expect(readRepoDir(dir)?.map(e => e.name).sort()).toEqual(['README.md', 'cmd', 'docs', 'src']);
+  });
+
+  test.skipIf(!posix)('a project reached through a link reads its own files', () => {
+    const { dir, outside } = fixture();
+    put(dir, 'README.md', '# Demo\n');
+    const alias = join(outside, 'alias');
+    symlinkSync(dir, alias);
+    expect(readRepoFile(alias, 'README.md')).toBe('# Demo\n');
+    expect(repoFile(alias, 'README.md')).toBe(join(dir, 'README.md'));
+  });
+});

--- a/tests/detect/detection-links.test.ts
+++ b/tests/detect/detection-links.test.ts
@@ -1,0 +1,362 @@
+/**
+ * BRAKE: detection reads stay inside the project (7.13.1).
+ *
+ * Detection followed a link out of the project. A repo whose README.md,
+ * package.json or pyproject.toml is a link to a file outside it had that
+ * file's text read and written into project.faf (project.goal,
+ * human_context.what, …), CLAUDE.md, AGENTS.md and the command output — and
+ * with `faf git <url>` a hostile repo could point README.md at
+ * ~/.aws/credentials. 7.13 protected the writers and the .faf/.fafm readers,
+ * not detection.
+ *
+ * Now every detection read goes through repoFile (src/core/safe-write.ts): a
+ * file whose real path leaves the project, runs through .git, or dangles is
+ * absent to detection. A link inside the project is still followed. `faf git`
+ * clones with core.symlinks=false, so a cloned repo's links arrive as plain
+ * files holding the link's text.
+ *
+ * Each test puts a link to a mkdtemp "secret" file outside the project into
+ * its fixture, and each fails on 7.13.0: the secret's text reaches the output.
+ * Every folder is a mkdtemp folder; every CLI run gets a HOME and a TMPDIR of
+ * its own.
+ */
+import { afterAll, describe, test, expect } from 'bun:test';
+import { lstatSync, mkdirSync, readdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from 'fs';
+import { basename, dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { execFileSync, spawnSync } from 'child_process';
+import { assembleFreshFaf, updateExistingFaf } from '../../src/detect/assemble.js';
+import { authorFafFromRepo } from '../../src/detect/git-repo.js';
+import { enrichFromRepo } from '../../src/detect/enrich.js';
+import { relentlessContextDetailed } from '../../src/detect/relentless.js';
+import { turboCatScan } from '../../src/detect/turbo-cat.js';
+import { detectStack } from '../../src/detect/stack.js';
+import { interrogateRepo } from '../../src/interrogate/index.js';
+import { renderAgentsMd } from '../../src/interop/agents.js';
+import { renderClaudeMd } from '../../src/interop/claude.js';
+import { serializeFaf } from '../../src/interop/faf.js';
+import { cloneArgs, dropLinkPlaceholders } from '../../src/commands/git.js';
+import { detectSubdirStacks } from '../../src/detect/scanner.js';
+import { readFafa } from '../../src/interop/cards.js';
+import { SafePathError } from '../../src/core/safe-write.js';
+import type { FafData } from '../../src/core/types.js';
+import { tempDirs } from '../helpers/temp-dirs.js';
+
+const tempFolders = tempDirs();
+afterAll(() => tempFolders.removeAll());
+
+const posix = process.platform !== 'win32';
+const hasGit = spawnSync('git', ['--version'], { encoding: 'utf-8' }).status === 0;
+const CLI = join(import.meta.dir, '../../src/cli.ts');
+const mk = (tag: string): string => realpathSync(tempFolders.mkdtemp(join(tmpdir(), `faf-p1-${tag}-`)));
+
+// ── The secret files, outside every project ─────────────────────────────────
+// Each carries the canary, in the fields detection copies: README prose,
+// package.json name / description / repository / dependencies. pyproject's
+// text reaches the output only as what detection derives from it — its
+// data-science dependency, its linter, its test runner — so those words are
+// its canaries too. The paths themselves carry no canary: a link's text is
+// not the secret.
+const CANARY = 'canary-7f3a';
+const README_SECRET =
+  '# Credentials\n\n' +
+  '[default] aws_secret_access_key = CANARY-7F3A-this-line-is-a-secret-kept-outside-the-project\n\n' +
+  '## Why\n\nCANARY-7F3A: the text of a file outside the project must never be read.\n\n' +
+  '## Audience\n\nBuilt for developers who keep CANARY-7F3A credentials here.\n\n' +
+  '## Architecture\n\nCANARY-7F3A how-section text that is long enough to be picked up.\n';
+const PKG_SECRET = `${JSON.stringify(
+  {
+    name: 'canary-7f3a-pkg',
+    description: 'CANARY-7F3A description of a package.json kept outside the project',
+    repository: 'https://example.com/canary-7f3a',
+    type: 'module',
+    scripts: { build: 'tsc', test: 'bun test', lint: 'eslint .' },
+    dependencies: { 'canary-7f3a-dep': '1.0.0' },
+    devDependencies: { typescript: '^5.0.0' },
+  },
+  null,
+  2,
+)}\n`;
+const PY_SECRET =
+  '[project]\nname = "canary-7f3a"\ndescription = "CANARY-7F3A pyproject kept outside the project"\n' +
+  'dependencies = ["matplotlib"]\n\n[tool.ruff]\nline-length = 100\n\n[tool.pytest.ini_options]\naddopts = "-q"\n';
+const CANARIES = [CANARY, 'matplotlib', 'ruff', 'pytest'];
+
+const OUTSIDE = mk('outside');
+const SECRETS: Record<string, [file: string, text: string]> = {
+  'README.md': [join(OUTSIDE, 'credentials.md'), README_SECRET],
+  'package.json': [join(OUTSIDE, 'credentials.json'), PKG_SECRET],
+  'pyproject.toml': [join(OUTSIDE, 'credentials.toml'), PY_SECRET],
+};
+for (const [file, text] of Object.values(SECRETS)) {writeFileSync(file, text);}
+
+/** The canaries `text` holds (none, when detection stayed inside the project). */
+function leaks(text: string): string[] {
+  const t = text.toLowerCase();
+  return CANARIES.filter(c => t.includes(c));
+}
+
+/** A project whose `names` (README.md, package.json, pyproject.toml) are links
+ *  to the secrets outside it, plus `files` of its own. */
+function project(names: string[], files: Record<string, string> = {}): string {
+  const dir = mk('project');
+  for (const name of names) {symlinkSync(SECRETS[name][0], join(dir, name));}
+  for (const [rel, text] of Object.entries(files)) {
+    mkdirSync(dirname(join(dir, rel)), { recursive: true });
+    writeFileSync(join(dir, rel), text);
+  }
+  return dir;
+}
+
+/** The text of every regular file under `dir` — the links and `.git` are the
+ *  fixture's own, not faf's output. */
+function writtenFiles(dir: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  const walk = (d: string): void => {
+    for (const name of readdirSync(d)) {
+      if (name === '.git') {continue;}
+      const p = join(d, name);
+      const st = lstatSync(p);
+      if (st.isDirectory()) {walk(p);}
+      else if (st.isFile()) {out[p.slice(dir.length + 1)] = readFileSync(p, 'utf-8');}
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+/** The secrets are exactly as the fixture wrote them. */
+function expectSecretsUntouched(): void {
+  for (const [file, text] of Object.values(SECRETS)) {expect(readFileSync(file, 'utf-8')).toBe(text);}
+}
+
+// ── The CLI, from source, with a HOME and a TMPDIR of its own ───────────────
+interface Run { status: number | null; out: string; err: string }
+function env(extra: Record<string, string> = {}): Record<string, string> {
+  const e: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {if (v !== undefined) {e[k] = v;}}
+  for (const k of ['FAF_PRO', 'ANTHROPIC_API_KEY', 'CLAUDE_API_KEY', 'CLAUDE_CONFIG_DIR']) {delete e[k];}
+  return { ...e, HOME: mk('home'), TMPDIR: mk('tmp'), NO_COLOR: '1', CI: '1', GIT_CONFIG_NOSYSTEM: '1', GIT_TERMINAL_PROMPT: '0', ...extra };
+}
+function run(cwd: string, args: string[], extra: Record<string, string> = {}): Run {
+  const r = spawnSync(process.execPath, [CLI, ...args], { cwd, encoding: 'utf-8', env: env(extra), stdio: ['ignore', 'pipe', 'pipe'] });
+  return { status: r.status, out: r.stdout ?? '', err: r.stderr ?? '' };
+}
+
+/** A run that succeeded and printed nothing of the secrets. */
+function expectCleanRun(r: Run, what: string): void {
+  expect({ what, status: r.status, err: r.status === 0 ? '' : r.err }).toEqual({ what, status: 0, err: '' });
+  expect({ what, stdout: leaks(r.out), stderr: leaks(r.err) }).toEqual({ what, stdout: [], stderr: [] });
+}
+
+/** No file faf wrote under `dir` holds a canary. */
+function expectCleanFiles(dir: string): void {
+  const files = writtenFiles(dir);
+  const found = Object.entries(files).filter(([, text]) => leaks(text).length > 0).map(([rel, text]) => `${rel}: ${leaks(text).join(', ')}`);
+  expect(found).toEqual([]);
+}
+
+const ALL = ['README.md', 'package.json', 'pyproject.toml'];
+
+describe('BRAKE: detection never reads a file through a link out of the project', () => {
+  test.skipIf(!posix)('faf init, faf auto, faf export --agents and faf sync: the secrets appear nowhere', () => {
+    const dir = project(ALL, { 'src/index.ts': 'export const x = 1;\n' });
+
+    expectCleanRun(run(dir, ['init']), 'faf init');
+    expectCleanFiles(dir);
+    expectCleanRun(run(dir, ['auto']), 'faf auto (existing project.faf)');
+    expectCleanFiles(dir);
+    expectCleanRun(run(dir, ['export', '--agents']), 'faf export --agents');
+    expectCleanRun(run(dir, ['sync']), 'faf sync');
+
+    const files = writtenFiles(dir);
+    for (const name of ['project.faf', 'AGENTS.md', 'CLAUDE.md']) {expect(Object.keys(files)).toContain(name);}
+    expectCleanFiles(dir);
+    // The links are the user's, left as they were; the secrets are unread and unchanged.
+    for (const name of ALL) {expect(lstatSync(join(dir, name)).isSymbolicLink()).toBe(true);}
+    expectSecretsUntouched();
+  });
+
+  test.skipIf(!posix)('faf auto on a project with no project.faf: the secrets appear nowhere', () => {
+    const dir = project(ALL);
+    expectCleanRun(run(dir, ['auto']), 'faf auto (new project.faf)');
+    expect(readFileSync(join(dir, 'project.faf'), 'utf-8')).toContain('project:');
+    expectCleanFiles(dir);
+    expectSecretsUntouched();
+  });
+
+  // Each linked file on its own, through every library entry point that reads the repo.
+  for (const name of ALL) {
+    test.skipIf(!posix)(`${name} → a file outside: authorFafFromRepo / assembleFreshFaf / updateExistingFaf / enrichFromRepo read none of it`, () => {
+      const dir = project([name]);
+      const existing = { project: { name: 'mine' }, human_context: { who: '' } };
+      const fresh = assembleFreshFaf(dir) as FafData;
+      const outputs: Record<string, string> = {
+        authorFafFromRepo: serializeFaf(authorFafFromRepo(dir, { repoUrl: 'https://github.com/owner/linked.git' })),
+        assembleFreshFaf: serializeFaf(fresh),
+        updateExistingFaf: serializeFaf(updateExistingFaf(dir, existing) as FafData),
+        enrichFromRepo: JSON.stringify(enrichFromRepo(dir, fresh)),
+        'AGENTS.md': renderAgentsMd(enrichFromRepo(dir, fresh)),
+        'CLAUDE.md': renderClaudeMd(fresh),
+        detectStack: JSON.stringify(detectStack(dir)),
+        interrogateRepo: JSON.stringify(interrogateRepo(dir)),
+        relentlessContextDetailed: JSON.stringify(relentlessContextDetailed(dir)),
+        turboCatScan: JSON.stringify(turboCatScan(dir)),
+      };
+      const found = Object.entries(outputs).filter(([, text]) => leaks(text).length > 0).map(([fn, text]) => `${fn}: ${leaks(text).join(', ')}`);
+      expect(found).toEqual([]);
+      // Absent, not merely unread: the linked file is no key file, and says nothing of the stack.
+      const enriched = enrichFromRepo(dir, fresh);
+      expect(enriched.key_files ?? []).not.toContain(name);
+      expect(fresh.project?.main_language ?? '').toBe('');
+      expectSecretsUntouched();
+    });
+  }
+
+  test.skipIf(!posix)('a link inside the project still works: README.md → docs/README.md is read', () => {
+    const inProject = '# Demo\n\nAn in-project README that faf reads through its link, as before.\n';
+    const dir = project(['package.json'], { 'docs/README.md': inProject });
+    symlinkSync(join('docs', 'README.md'), join(dir, 'README.md'));
+
+    const fresh = assembleFreshFaf(dir) as FafData;
+    expect(fresh.project?.goal).toBe('An in-project README that faf reads through its link, as before.');
+    expect(leaks(serializeFaf(fresh))).toEqual([]);
+
+    expectCleanRun(run(dir, ['init']), 'faf init');
+    expect(readFileSync(join(dir, 'project.faf'), 'utf-8')).toContain('An in-project README that faf reads through its link');
+    expectCleanFiles(dir);
+  });
+
+  test.skipIf(!posix)('a file reached through a folder that links out, a link into .git and a dangling link are absent', () => {
+    const inGit = '[package]\nname = "in-git"\ndescription = "CANARY-7F3A description kept inside .git"\n';
+    const dir = project(['package.json'], { '.git/in-git.toml': inGit });
+    symlinkSync(OUTSIDE, join(dir, 'docs')); // docs/ → the folder the secrets are in
+    symlinkSync(join('docs', 'credentials.md'), join(dir, 'README.md')); // through docs/, out
+    symlinkSync(join('.git', 'in-git.toml'), join(dir, 'Cargo.toml')); // into .git
+    symlinkSync(join(dir, 'nowhere.toml'), join(dir, 'pyproject.toml')); // dangling
+
+    const outputs = [
+      serializeFaf(assembleFreshFaf(dir) as FafData),
+      JSON.stringify(interrogateRepo(dir)),
+      JSON.stringify(relentlessContextDetailed(dir)),
+      JSON.stringify(turboCatScan(dir)),
+    ];
+    for (const text of outputs) {expect(leaks(text)).toEqual([]);}
+    expectCleanRun(run(dir, ['init']), 'faf init');
+    expectCleanFiles(dir);
+    expectSecretsUntouched();
+  });
+});
+
+// ── faf git: a cloned repo's links arrive as plain files ────────────────────
+/** A bare repo `<remote>/linkrepo.git` whose README.md and package.json are
+ *  links (absolute) to the secrets outside it — the hostile repo. */
+function hostileRemote(): string {
+  const work = mk('work');
+  const gitEnv = { ...process.env, HOME: mk('githome'), GIT_CONFIG_NOSYSTEM: '1' };
+  const git = (cwd: string, args: string[]): void => {
+    execFileSync('git', args, { cwd, env: gitEnv, stdio: 'pipe' });
+  };
+  git(work, ['init', '-q']);
+  symlinkSync(SECRETS['README.md'][0], join(work, 'README.md'));
+  symlinkSync(SECRETS['package.json'][0], join(work, 'package.json'));
+  git(work, ['add', '-A']);
+  git(work, ['-c', 'user.email=t@faf.one', '-c', 'user.name=faf', '-c', 'commit.gpgsign=false', 'commit', '-qm', 'links out']);
+  const remote = mk('remote');
+  git(remote, ['clone', '-q', '--bare', work, join(remote, 'linkrepo.git')]);
+  return remote;
+}
+
+describe('BRAKE: faf git clones links as plain text files', () => {
+  test.skipIf(!posix || !hasGit)('the clone faf git runs gives README.md as a plain file holding the link text', () => {
+    const remote = hostileRemote();
+    const dest = join(mk('clone'), 'repo');
+    execFileSync('git', cloneArgs(`file://${remote}/linkrepo.git`, dest), {
+      env: { ...process.env, HOME: mk('githome'), GIT_CONFIG_NOSYSTEM: '1' },
+      stdio: 'pipe',
+    });
+    for (const name of ['README.md', 'package.json']) {
+      expect({ name, link: lstatSync(join(dest, name)).isSymbolicLink() }).toEqual({ name, link: false });
+      expect(readFileSync(join(dest, name), 'utf-8')).toBe(SECRETS[name][0]);
+    }
+    expect(leaks(serializeFaf(authorFafFromRepo(dest)))).toEqual([]);
+    expectSecretsUntouched();
+  });
+
+  test.skipIf(!posix || !hasGit)('faf git <url> on a repo whose README.md links to a secret: the secret appears nowhere', () => {
+    const remote = hostileRemote();
+    const home = mk('home');
+    // `faf git faf-links/linkrepo` → https://github.com/faf-links/linkrepo.git → the local bare repo.
+    writeFileSync(
+      join(home, '.gitconfig'),
+      `[url "file://${remote}/"]\n\tinsteadOf = https://github.com/faf-links/\n[protocol "file"]\n\tallow = always\n`,
+    );
+    const cwd = mk('gitcwd');
+    const r = run(cwd, ['git', 'faf-links/linkrepo'], { HOME: home, GIT_CONFIG_GLOBAL: join(home, '.gitconfig') });
+    expectCleanRun(r, 'faf git');
+    const faf = readFileSync(join(cwd, 'project.faf'), 'utf-8');
+    expect(leaks(faf)).toEqual([]);
+    // README.md arrived as a plain file holding the link's text; faf takes that
+    // placeholder out of its clone, so the link text is not read as the README.
+    expect(faf).not.toContain(basename(OUTSIDE));
+    expect(faf).toContain('name: linkrepo');
+    expectCleanFiles(cwd);
+    expectSecretsUntouched();
+  });
+});
+
+// ── 7.13.1 check follow-ups: in-project subfolder links, the link text, .fafa ──
+describe('BRAKE: the project folder bounds subfolder scans; link text is never a fact; .fafa is read safely', () => {
+  test.skipIf(!posix)('a subfolder manifest linked elsewhere inside the project is followed; one linked out is absent', () => {
+    const dir = mk('subdirs');
+    mkdirSync(join(dir, 'api'), { recursive: true });
+    writeFileSync(join(dir, 'api', 'go.mod'), 'module example.com/api\n\ngo 1.22\n');
+    mkdirSync(join(dir, 'shared'), { recursive: true });
+    writeFileSync(join(dir, 'shared', 'web-package.json'), `${JSON.stringify({ name: 'web', dependencies: { react: '18.0.0' } })}\n`);
+    mkdirSync(join(dir, 'web'), { recursive: true });
+    symlinkSync('../shared/web-package.json', join(dir, 'web', 'package.json'));
+    mkdirSync(join(dir, 'leak'), { recursive: true });
+    symlinkSync(SECRETS['package.json'][0], join(dir, 'leak', 'package.json'));
+    const stacks = detectSubdirStacks(dir);
+    expect(stacks.map(s => s.name).sort()).toContain('web');
+    expect(stacks.find(s => s.name === 'web')?.topFramework).toBe('React');
+    expect(stacks.map(s => s.name)).not.toContain('leak');
+    expect(leaks(JSON.stringify(stacks))).toEqual([]);
+    expectSecretsUntouched();
+  });
+
+  test.skipIf(!posix || !hasGit)('faf git: an in-repo README link (README.md -> docs/README.md) never becomes project.goal', () => {
+    const work = mk('work-inrepo');
+    const gitEnv = { ...process.env, HOME: mk('githome'), GIT_CONFIG_NOSYSTEM: '1' };
+    const git = (cwd: string, args: string[]): void => { execFileSync('git', args, { cwd, env: gitEnv, stdio: 'pipe' }); };
+    git(work, ['init', '-q']);
+    mkdirSync(join(work, 'docs'), { recursive: true });
+    writeFileSync(join(work, 'docs', 'README.md'), '# inrepo\n\nA tool the docs folder describes.\n');
+    symlinkSync('docs/README.md', join(work, 'README.md'));
+    git(work, ['add', '-A']);
+    git(work, ['-c', 'user.email=t@faf.one', '-c', 'user.name=faf', '-c', 'commit.gpgsign=false', 'commit', '-qm', 'in-repo link']);
+    const dest = join(mk('clone-inrepo'), 'repo');
+    execFileSync('git', cloneArgs(`file://${work}`, dest), { env: gitEnv, stdio: 'pipe' });
+    expect(readFileSync(join(dest, 'README.md'), 'utf-8')).toBe('docs/README.md'); // the placeholder
+    expect(dropLinkPlaceholders(dest)).toBe(1);
+    const faf = serializeFaf(authorFafFromRepo(dest));
+    expect(faf).not.toContain('docs/README.md');
+  });
+
+  test.skipIf(!posix)('agent.fafa that links out of its folder is refused, never read; a same-name link inside is read', () => {
+    const dir = mk('fafa');
+    const secret = join(OUTSIDE, 'agent-secret.fafa');
+    writeFileSync(secret, `name: ${CANARY}\n`);
+    symlinkSync(secret, join(dir, 'agent.fafa'));
+    let err: unknown;
+    try { readFafa(join(dir, 'agent.fafa')); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(SafePathError);
+    expect(leaks(String((err as Error)?.message ?? ''))).toEqual([]);
+
+    const ok = mk('fafa-ok');
+    mkdirSync(join(ok, 'docs'), { recursive: true });
+    writeFileSync(join(ok, 'docs', 'agent.fafa'), 'name: inside-agent\n');
+    symlinkSync('docs/agent.fafa', join(ok, 'agent.fafa'));
+    expect((readFafa(join(ok, 'agent.fafa')) as { name?: string }).name).toBe('inside-agent');
+  });
+});

--- a/tests/wjttc/git-deepen.test.ts
+++ b/tests/wjttc/git-deepen.test.ts
@@ -62,9 +62,9 @@ describe('WJTTC — faf git (deepened) + 7.0 cohesion', () => {
 
   // ── ⚙️ ENGINE — versioned context (--ref) ───────────────────────────────────
   describe('⚙️ ENGINE — cloneArgs', () => {
-    test('no ref → shallow clone, no --branch', () => {
+    test('no ref → shallow clone, links as plain files, no --branch', () => {
       expect(cloneArgs('https://x/y.git', '/tmp/z')).toEqual([
-        'clone', '--depth', '1', '--', 'https://x/y.git', '/tmp/z',
+        'clone', '-c', 'core.symlinks=false', '--depth', '1', '--', 'https://x/y.git', '/tmp/z',
       ]);
     });
     test('ref → --branch pins the branch/tag (versioned context)', () => {

--- a/tests/wjttc/git.test.ts
+++ b/tests/wjttc/git.test.ts
@@ -23,7 +23,7 @@ import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { execFileSync } from 'child_process';
-import { normalizeGitUrl } from '../../src/commands/git.js';
+import { cloneArgs, normalizeGitUrl } from '../../src/commands/git.js';
 import { tafCommand } from '../../src/commands/taf.js';
 import { assembleFreshFaf } from '../../src/detect/assemble.js';
 import { writeFaf, readFafRaw } from '../../src/interop/faf.js';
@@ -270,7 +270,7 @@ describe('WJTTC TYRE: faf git — the real road (real clone → real .faf → re
       });
 
       // The EXACT no-shell clone path faf git uses — local source, no network.
-      execFileSync('git', ['clone', '--depth', '1', '--', src, dest], { stdio: 'pipe' });
+      execFileSync('git', cloneArgs(src, dest), { stdio: 'pipe' });
       expect(existsSync(join(dest, 'package.json'))).toBe(true);
 
       // The real extraction + scoring pipeline on the cloned repo.


### PR DESCRIPTION
A security patch in The Co-Author Edition. faf-cli's detection no longer follows a link out of your project, so a hostile repo can't pull a file like `~/.aws/credentials` into project.faf, CLAUDE.md, AGENTS.md or your AI's context. It predates 7.13.

- **Detection reads:** every one goes through one helper. A file that links outside the project, into `.git` or to nothing is absent. In-project links still work, from the root and from subfolders.
- **`faf git`:** it clones with `core.symlinks=false` and drops the link placeholders from its temporary clone.
- **`faf cards`:** it reads `agent.fafa` through the safe path.
- **Display:** also ships 479a31b8, which shows `slotignored` as `slotignored`, never N/A.

**Tests:** 22 new tests, each failing without its fix. Suite 2017 pass / 1 skip / 0 fail.

**Fixed regression check:**
- detection output is byte-identical on 7 link-free trees;
- zero owner-rule verdict changes;
- no new failures in faf-mcp or claude-faf-mcp v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLZcQw6jmztzmf6xDv8L2D